### PR TITLE
Use context object's url to create the cache key instead of the portal_url

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 2.3.2 (unreleased)
 ------------------
 
+- Use context object's url to create the cache key instead of the portal_url.
+  [erral]
+
 - Avoid extra space at the end of icon alt attributes.
   [davisagli]
 

--- a/plone/app/layout/sitemap/sitemap.py
+++ b/plone/app/layout/sitemap/sitemap.py
@@ -17,10 +17,10 @@ def _render_cachekey(fun, self):
     if not mtool.isAnonymousUser():
         raise ram.DontCache
 
-    url_tool = getToolByName(self.context, 'portal_url')
+    url = self.context.absolute_url()
     catalog = getToolByName(self.context, 'portal_catalog')
     counter = catalog.getCounter()
-    return '%s/%s/%s' % (url_tool(), self.filename, counter)
+    return '%s/%s/%s' % (url, self.filename, counter)
 
 
 class SiteMapView(BrowserView):


### PR DESCRIPTION
Otherwise you can't get different sitemaps for different INavigationRoot enabled folders, for example, when using LinguaPlone and getting sitemaps for different language content. Without this change, you will always get the cached content.
