### PR TITLE
Add 'subsection' prefix to section classnames

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 2.3.3 (unreleased)
 ------------------
 
+- Add 'subsection' prefix to the all sections below to avoid classnames
+  that start with digits, which is not permitted by the CSS standard.
+  [erral]
+
 - Display publication date only if Effective date is set, regardless of object
   state. Tickets:
   https://dev.plone.org/ticket/13045 and https://dev.plone.org/ticket/13046
@@ -40,11 +44,11 @@ Changelog
 2.3 (2012-08-11)
 ----------------
 
-- Change breadcrumb separator to / (slash character) for accessibility, and added SEO benefits. 
+- Change breadcrumb separator to / (slash character) for accessibility, and added SEO benefits.
   see https://dev.plone.org/ticket/12904
   [polyester]
 
-- Add language atribute to presentation.pt for WCAG 2.0 compliance. 
+- Add language atribute to presentation.pt for WCAG 2.0 compliance.
   See https://dev.plone.org/ticket/12902
   [rmatt, polyester]
 
@@ -72,11 +76,11 @@ Changelog
 2.2.7 (2012-08-11)
 ------------------
 
-- Change breadcrumb separator to / (slash character) for accessibility, and added SEO benefits. 
+- Change breadcrumb separator to / (slash character) for accessibility, and added SEO benefits.
   see https://dev.plone.org/ticket/12904
   [polyester]
 
-- Add language atribute to presentation.pt for WCAG 2.0 compliance. 
+- Add language atribute to presentation.pt for WCAG 2.0 compliance.
   See https://dev.plone.org/ticket/12902
   [rmatt, polyester]
 
@@ -142,7 +146,7 @@ Changelog
   Fixes http://dev.plone.org/plone/ticket/11869
   [davisagli]
 
-- Fix bug where getNavigationRootObject goes into infinite loop if context is 
+- Fix bug where getNavigationRootObject goes into infinite loop if context is
   None.
   Fixes http://dev.plone.org/plone/ticket/12186
   [anthonygerrard]
@@ -185,7 +189,7 @@ Changelog
 
 - Set the search form to submit to @@search in order to use the new
   search results page.
-  [elvix] 
+  [elvix]
 
 - Updated the BaseIcon to return its html tag when called.
   [elvix]
@@ -204,7 +208,7 @@ Changelog
 - Switching 'Skip to navigation' to be linked to the global navigation instead
   of the navigation portlet.
   This fixes http://dev.plone.org/plone/ticket/11728
-  [spliter]  
+  [spliter]
 
 
 2.1.8 - 2011-07-04

--- a/plone/app/layout/globals/layout.py
+++ b/plone/app/layout/globals/layout.py
@@ -169,7 +169,7 @@ class LayoutPolicy(BrowserView):
                 except KeyError:
                     depth = 4
                 if depth > 1:
-                    classes = [contentPath[1]]
+                    classes = ['subsection-%s' % contentPath[1]]
                     for section in contentPath[2:depth]:
                         classes.append('-'.join([classes[-1], section]))
                     body_class += " %s" % ' '.join(classes)

--- a/plone/app/layout/globals/tests/test_layout.py
+++ b/plone/app/layout/globals/tests/test_layout.py
@@ -80,8 +80,8 @@ class TestLayoutView(GlobalsTestCase):
         view = context.restrictedTraverse('@@plone_layout')
         template = context.document_view
         body_class = view.bodyClass(template, view)
-        assert 'folder2 folder2-folder3' in body_class
-        assert ' folder2-folder3-page' in body_class
+        assert 'subsection-folder2 subsection-folder2-folder3' in body_class
+        assert ' subsection-folder2-folder3-page' in body_class
 
     def testBodyClassWithEverySectionTurnedOff(self):
         registry = getUtility(IRegistry)
@@ -95,8 +95,8 @@ class TestLayoutView(GlobalsTestCase):
         view = context.restrictedTraverse('@@plone_layout')
         template = context.document_view
         body_class = view.bodyClass(template, view)
-        assert 'folder2 folder2-folder3' not in body_class
-        assert ' folder2-folder3-page' not in body_class
+        assert 'subsection-folder2 subsection-folder2-folder3' not in body_class
+        assert ' subsection-folder2-folder3-page' not in body_class
 
 
 def test_suite():


### PR DESCRIPTION
If you have a folder with an id starting with a digit (for instance 2012), the generated classnames also start with a digit, which is not valid according to CSS spec:

http://www.w3.org/TR/CSS2/syndata.html#characters 

 In CSS, identifiers (including element names, classes, and IDs in selectors) can contain only the  characters [a-zA-Z0-9] and ISO 10646 characters U+00A0 and higher, plus the hyphen (-) and the underscore (_); they cannot start with a digit, two hyphens, or a hyphen followed by a digit. Identifiers can also contain escaped characters and any ISO 10646 character as a numeric code (see next item). For instance, the identifier "B&W?" may be written as "B&W\?" or "B\26 W\3F".

With this change we can guarantee that all classnames have "controlled" names
