### PR TITLE
Remove hardcoded link to personalize_form.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 2.3.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Personal bar viewlet home link simply links to the user actions list.
+  [danjacka]
 
 
 2.3.5 (2013-05-23)

--- a/plone/app/layout/viewlets/common.py
+++ b/plone/app/layout/viewlets/common.py
@@ -231,7 +231,6 @@ class PersonalBarViewlet(ViewletBase):
         context_state = getMultiAdapter((context, self.request),
                                         name=u'plone_context_state')
 
-        sm = getSecurityManager()
         self.user_actions = context_state.actions('user')
         self.anonymous = self.portal_state.anonymous()
 
@@ -239,11 +238,7 @@ class PersonalBarViewlet(ViewletBase):
             member = self.portal_state.member()
             userid = member.getId()
 
-            if sm.checkPermission('Portlets: View dashboard', context):
-                self.homelink_url = "%s/useractions" % self.navigation_root_url
-            else:
-                self.homelink_url = "%s/personalize_form" % (
-                                        self.navigation_root_url)
+            self.homelink_url = "%s/useractions" % self.navigation_root_url
 
             membership = getToolByName(context, 'portal_membership')
             member_info = membership.getMemberInfo(userid)


### PR DESCRIPTION
In fact, it's simple and predictable to always link to the user actions list.
