### PR TITLE
Implement a canonical link relation viewlet to be displayed by IHtmlHeadLinks viewlet manager

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,12 @@ Changelog
 2.3.6 (unreleased)
 ------------------
 
+- Implement a canonical link relation viewlet to be displayed by
+  IHtmlHeadLinks viewlet manager; this will prevent web indexers from indexing
+  the same object more than once, improving also the way these indexers deal
+  with images and files.
+  [hvelarde]
+
 - Add Dexterity support for the related items viewlet. Backported from master
   branch.
   [pabo]

--- a/plone/app/layout/links/configure.zcml
+++ b/plone/app/layout/links/configure.zcml
@@ -30,4 +30,11 @@
         permission="zope2.View"
         />
 
+    <browser:viewlet
+        name="plone.links.canonical_url"
+        manager="plone.app.layout.viewlets.interfaces.IHtmlHeadLinks"
+        class=".viewlets.CanonicalURL"
+        permission="zope2.View"
+        />
+
 </configure>

--- a/plone/app/layout/links/tests/test_canonical_url.py
+++ b/plone/app/layout/links/tests/test_canonical_url.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from plone.app.layout.testing import INTEGRATION_TESTING
+from plone.testing.z2 import Browser
+
+import unittest2 as unittest
+
+
+class ViewletTestCase(unittest.TestCase):
+
+    layer = INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_canonical_url_viewlet(self):
+        portal_url = self.portal.absolute_url()
+        canonical_link = u'<link rel="canonical" href="%s"' % portal_url
+        browser = Browser(self.layer['app'])
+        # the page must contain the canonical URL link
+        browser.open(portal_url)
+        self.assertIn(canonical_link, browser.contents)
+        # opening the same page using a different view must return the same
+        # canonical URL
+        browser.open(portal_url + '/view')
+        self.assertIn(canonical_link, browser.contents)

--- a/plone/app/layout/links/viewlets.py
+++ b/plone/app/layout/links/viewlets.py
@@ -1,6 +1,7 @@
 from StringIO import StringIO
 
 from plone.memoize import ram
+from plone.memoize import view
 from plone.memoize.compress import xhtml_compress
 from zope.component import getMultiAdapter
 
@@ -79,8 +80,8 @@ class RSSViewlet(ViewletBase):
         settings = IFeedSettings(obj, None)
         if settings is None:
             return []
-        factory = getUtility(IVocabularyFactory,
-            "plone.app.vocabularies.SyndicationFeedTypes")
+        factory = getUtility(
+            IVocabularyFactory, "plone.app.vocabularies.SyndicationFeedTypes")
         vocabulary = factory(self.context)
         urls = []
         for typ in settings.feed_types:
@@ -119,3 +120,19 @@ class RSSViewlet(ViewletBase):
                 self.rsslinks.extend(self.getRssLinks(self.context))
 
     index = ViewPageTemplateFile('rsslink.pt')
+
+
+class CanonicalURL(ViewletBase):
+    """Defines a canonical link relation viewlet to be displayed across the
+    site. A canonical page is the preferred version of a set of pages with
+    highly similar content. For more information, see:
+    https://tools.ietf.org/html/rfc6596
+    https://support.google.com/webmasters/answer/139394?hl=en
+    """
+
+    @view.memoize
+    def render(self):
+        context_state = getMultiAdapter(
+            (self.context, self.request), name=u'plone_context_state')
+        canonical_url = context_state.canonical_object_url()
+        return u'    <link rel="canonical" href="%s" />' % canonical_url

--- a/plone/app/layout/testing.py
+++ b/plone/app/layout/testing.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+from plone.app.testing import FunctionalTesting
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import PLONE_FIXTURE
+from plone.app.testing import PloneSandboxLayer
+
+
+class Fixture(PloneSandboxLayer):
+
+    defaultBases = (PLONE_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        # Load ZCML
+        import plone.app.layout
+        self.loadZCML(package=plone.app.layout)
+
+FIXTURE = Fixture()
+INTEGRATION_TESTING = IntegrationTesting(
+    bases=(FIXTURE,),
+    name='plone.app.layout:Integration',
+)
+FUNCTIONAL_TESTING = FunctionalTesting(
+    bases=(FIXTURE,),
+    name='plone.app.layout:Functional',
+)


### PR DESCRIPTION
this will prevent web indexers from indexing the same object more than once, improving also the way these indexers deal with images and files.

for more information, see:

https://tools.ietf.org/html/rfc6596
https://support.google.com/webmasters/answer/139394?hl=en
