### PR TITLE
use conditional import to detect presence of dexterity related item behavior

### DIFF
--- a/plone/app/layout/viewlets/content.py
+++ b/plone/app/layout/viewlets/content.py
@@ -158,7 +158,7 @@ class ContentRelatedItems(ViewletBase):
                 related = context.relatedItems
                 if not related:
                     return ()
-                res = [self.rel2brain(rel) for rel in related]
+                res = [self.rel2brain(rel) for rel in related if not rel.isBroken()]
 
         return res
 


### PR DESCRIPTION
Checking for successful import should be enough. Looking up the distribution is just an additional source for possible typos. (like in this case where the actual distribution name is plone.app.relationfield).

cheers,
