### PR TITLE
Fix body class attribute errors when the user role contains space

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.4a1 (unreleased)
 ------------------
 
+- Fix body class attribute errors when the user role contains space.
+  [Jian Aijun]
+
 - Remove dependency on unittest2 as we are not going to test against
   Python 2.6 anymore on Plone 5.0.
   [hvelarde]

--- a/plone/app/layout/globals/layout.py
+++ b/plone/app/layout/globals/layout.py
@@ -197,6 +197,6 @@ class LayoutPolicy(BrowserView):
         else:
             user = membership.getAuthenticatedMember()
             for role in user.getRolesInContext(self.context):
-                body_class += ' userrole-' + role.lower()
+                body_class += ' userrole-' + role.lower().replace(' ', '-')
 
         return body_class


### PR DESCRIPTION
Fix body class attribute errors when the user role contains space.
i.e., 'Site Administrator'
