### PR TITLE
Plip10359 security controlpanel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 2.5.4 (unreleased)
 ------------------
 
+- Read ``allow_anon_views_about`` settings from the registry instead of portal
+  properties (see https://github.com/plone/Products.CMFPlone/issues/216).
+  [jcerjak]
+
 - Added support for site logos stored in the portal registry via the site
   control panel for the logo viewlet with a fallback to the ``OFS.Image``
   based ``logo.png`` file. Removed support of long-gone

--- a/plone/app/layout/links/viewlets.py
+++ b/plone/app/layout/links/viewlets.py
@@ -13,6 +13,7 @@ from plone.app.uuid.utils import uuidToObject
 from zope.schema.interfaces import IVocabularyFactory
 from zope.component import getUtility
 from plone.registry.interfaces import IRegistry
+from Products.CMFPlone.interfaces import ISecuritySchema
 from Products.CMFPlone.interfaces.syndication import IFeedSettings
 from Products.CMFPlone.interfaces.syndication import ISiteSyndicationSettings
 
@@ -62,12 +63,13 @@ class AuthorViewlet(ViewletBase):
                                      name='plone_tools')
 
     def show(self):
-        properties = self.tools.properties()
-        site_properties = getattr(properties, 'site_properties')
         anonymous = self.portal_state.anonymous()
-        allowAnonymousViewAbout = site_properties.getProperty(
-            'allowAnonymousViewAbout', True)
-        return not anonymous or allowAnonymousViewAbout
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(
+            ISecuritySchema,
+            prefix='plone',
+        )
+        return not anonymous or settings.allow_anon_views_about
 
     def render(self):
         if self.show():

--- a/plone/app/layout/viewlets/content.py
+++ b/plone/app/layout/viewlets/content.py
@@ -6,14 +6,17 @@ from zope.component import getMultiAdapter, queryMultiAdapter
 from AccessControl import getSecurityManager
 from Acquisition import aq_inner
 from DateTime import DateTime
+from plone.registry.interfaces import IRegistry
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.CMFCore.utils import _checkPermission
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFEditions.Permissions import AccessPreviousVersions
 from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.interfaces import ISecuritySchema
 from Products.CMFPlone.utils import base_hasattr
 from Products.CMFPlone.utils import log
+from zope.component import getUtility
 
 from plone.app.layout.globals.interfaces import IViewView
 from plone.app.layout.viewlets import ViewletBase
@@ -64,11 +67,12 @@ class DocumentBylineViewlet(ViewletBase):
         self.has_pam = HAS_PAM
 
     def show(self):
-        properties = getToolByName(self.context, 'portal_properties')
-        site_properties = getattr(properties, 'site_properties')
-        allowAnonymousViewAbout = site_properties.getProperty(
-            'allowAnonymousViewAbout', True)
-        return not self.anonymous or allowAnonymousViewAbout
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(
+            ISecuritySchema,
+            prefix='plone',
+        )
+        return not self.anonymous or settings.allow_anon_views_about
 
     def show_history(self):
         has_access_preview_versions_permission = _checkPermission(

--- a/plone/app/layout/viewlets/tests/test_content.py
+++ b/plone/app/layout/viewlets/tests/test_content.py
@@ -1,18 +1,15 @@
-from z3c.relationfield import RelationValue
-from zope.component import getUtility
-from zope.component.hooks import getSite
-from zope.interface import Interface
-from zope.intid.interfaces import IIntIds
+from DateTime import DateTime
 from plone.app.layout.viewlets.tests.base import ViewletsTestCase
 from plone.app.layout.viewlets.content import DocumentBylineViewlet
 from plone.app.layout.viewlets.content import ContentRelatedItems
-from plone.locking.tests import addMember
 from plone.locking.interfaces import ILockable
 from plone.registry.interfaces import IRegistry
-from Products.CMFPlone.interfaces import ISecuritySchema
-
-from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces import ISecuritySchema
+from z3c.relationfield import RelationValue
+from zope.component import getUtility
+from zope.interface import Interface
+from zope.intid.interfaces import IIntIds
 
 try:
     import pkg_resources


### PR DESCRIPTION
Read security settings from the registry instead of portal properties. This is part of work on the security control panel migration: https://github.com/plone/Products.CMFPlone/issues/216

This should be merged along with https://github.com/plone/Products.CMFPlone/pull/362

Also did some restructuring of DocumentBylineViewlet tests.
