### PR TITLE
add some body tags to determine permission needed and roles needed to view

### DIFF
--- a/plone/app/layout/globals/layout.py
+++ b/plone/app/layout/globals/layout.py
@@ -187,18 +187,6 @@ class LayoutPolicy(BrowserView):
         if not getattr(view, '__ac_permissions__'):
             # should we have this special permission if it requires none?
             body_classes.append('viewpermission-none')
-        roles = []
-        if view is None or not getattr(view, '__ac_permissions__', tuple()):
-            roles = rolesForPermissionOn('Access contents information', context)
-        elif hasattr(view, '__roles__'):
-            roles = view.__roles__.rolesForPermissionOn(context)
-        elif hasattr(view, '__call____roles__'):
-            roles = view.__call____roles__.rolesForPermissionOn(context)
-        for role in roles:
-            body_classes.append('viewrole-' + normalizer.normalize(role))
-
-        # determine if this is the default view
-        #context.getLayout()
 
         # class for user roles
         membership = getToolByName(context, "portal_membership")

--- a/plone/app/layout/globals/layout.py
+++ b/plone/app/layout/globals/layout.py
@@ -180,13 +180,16 @@ class LayoutPolicy(BrowserView):
         if self.icons_visible():
             body_classes.append('icons-on')
 
-        # who is allowed to view this view.
-        # HACK: there must be a less dodgy way to do this?
-        for permission,roles in getattr(view, '__ac_permissions__', tuple()):
-            body_classes.append('viewpermission-' + normalizer.normalize(permission))
+        # permissions required. Useful to theme frontend and backend differently
+        permissions = []
         if not getattr(view, '__ac_permissions__'):
-            # should we have this special permission if it requires none?
-            body_classes.append('viewpermission-none')
+            permissions = ['none']
+        for permission,roles in getattr(view, '__ac_permissions__', tuple()):
+            permissions.append(normalizer.normalize(permission))
+        if 'none' in permissions or 'view' in permissions:
+            body_classes.append('frontend')
+        for permission in permissions:
+            body_classes.append('viewpermission-' + permission)
 
         # class for user roles
         membership = getToolByName(context, "portal_membership")


### PR DESCRIPTION
The goal is https://github.com/plone/Products.CMFPlone/issues/465, which is make it easy for a themer to theme the backend separate from the frontend while still using the toolbar.

I'm not sure the viewrole- ones are needed (or desired for security reasons). Maybe it should just say be restricted to viewrole-anonymous?

I think with this change a seperated theme could be as simple as 
<theme if="body.viewpermission-view,body.viewpermission-none,body.viewrole-anonymous" href="...">

Also, need some advice on the best way to implement this. Seems a bit hacky.