### PR TITLE
Fix data-base-url for file like objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.5.10 (unreleased)
 -------------------
 
+- Add view url to document as data-view-url
+  [ale-rt]
+
 - If toolbar logo is empty, use default
   [vangheem]
 

--- a/plone/app/layout/globals/patterns_settings.py
+++ b/plone/app/layout/globals/patterns_settings.py
@@ -16,6 +16,15 @@ class PatternsSettings(BrowserView):
     """
     implements(IPatternsSettingsRenderer)
 
+    def view_url(self):
+        ''' Facade to the homonymous plone_context_state method
+        '''
+        context_state = getMultiAdapter(
+            (self.context, self.request),
+            name='plone_context_state'
+        )
+        return context_state.view_url()
+
     def __call__(self):
         portal_state = getMultiAdapter(
             (self.context, self.request), name=u'plone_portal_state')
@@ -24,6 +33,7 @@ class PatternsSettings(BrowserView):
         base_url = portal_state.portal_url()
         result = {
             'data-base-url': self.context.absolute_url(),
+            'data-view-url': self.view_url(),
             'data-portal-url': base_url,
             'data-i18ncatalogurl': base_url + '/plonejsi18n'
         }

--- a/plone/app/layout/globals/tests/test_pattern_settings.py
+++ b/plone/app/layout/globals/tests/test_pattern_settings.py
@@ -16,11 +16,27 @@ class TestPatternSettings(GlobalsTestCase):
             self.assertTrue(isinstance(key, basestring))
             self.assertTrue(isinstance(value, basestring))
 
-    def testUrls(self):
+    def testFolderUrls(self):
         settings = PatternsSettings(self.folder, self.app.REQUEST)
         result = settings()
         self.assertEquals(result['data-base-url'], self.folder.absolute_url())
         self.assertEquals(result['data-portal-url'], self.portal.absolute_url())
+        self.assertEquals(result['data-view-url'], self.folder.absolute_url())
+
+    def testFileUrls(self):
+        self.folder.invokeFactory('File', 'file1')
+        file_obj = self.folder['file1']
+        settings = PatternsSettings(file_obj, self.app.REQUEST)
+        result = settings()
+        self.assertEquals(result['data-base-url'], file_obj.absolute_url())
+        self.assertEquals(
+            result['data-portal-url'],
+            self.portal.absolute_url()
+        )
+        self.assertEquals(
+            result['data-view-url'],
+            file_obj.absolute_url() + '/view'
+        )
 
     def testPatternOptions(self):
         registry = getUtility(IRegistry)


### PR DESCRIPTION
The data-base-url is used by pat-modal as a target for redirects
For file like objects the absolute_url leads to the file download
For this reason the proper redirect target should be the view url