### PR TITLE
Use getSite() to get portal

### DIFF
--- a/plone/app/layout/globals/portal.py
+++ b/plone/app/layout/globals/portal.py
@@ -1,6 +1,9 @@
 from zope.interface import implements
 from zope.component import getUtility
+from zope.component import providedBy
+from zope.component.hooks import getSite
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFPlone.interfaces import ISiteSchema
 from plone.memoize.view import memoize_contextless
 from plone.memoize.view import memoize
@@ -27,8 +30,12 @@ class PortalState(BrowserView):
 
     @memoize_contextless
     def portal(self):
-        context = aq_inner(self.context)
-        return getToolByName(context, 'portal_url').getPortalObject()
+        closest_site = getSite()
+        if closest_site is not None:
+            for potential_portal in closest_site.aq_chain:
+                if ISiteRoot in providedBy(potential_portal):
+                    return potential_portal
+        return None
 
     @memoize_contextless
     def portal_title(self):


### PR DESCRIPTION
If we want to use memoize_contextless then we shouldn't depend on the context.
See https://github.com/plone/Products.CMFPlone/issues/341

I was going to add a test that fails in master and passes with the new code, but it's tricky. I don't really want to assert that portal() doesn't use the context, but that its use of the context is consistent with its caching decorator, and I'm not sure that can be done without black magic.