### PR TITLE
Zope4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Adapt to changed Zope 4 ``broser:view`` semantics. We either need a ``template`` ZCML argument or a ``__call__`` method on the class.
+  [thet]
 
 
 2.5.17 (2015-11-26)

--- a/plone/app/layout/viewlets/content.py
+++ b/plone/app/layout/viewlets/content.py
@@ -511,8 +511,9 @@ class ContentHistoryViewlet(WorkflowHistoryViewlet):
 
 class ContentHistoryView(ContentHistoryViewlet):
 
-    index = ViewPageTemplateFile("content_history.pt")
-
     def __init__(self, context, request):
         super(ContentHistoryView, self).__init__(context, request, None, None)
         self.update()
+
+    def __call__(self):
+        return self.index()


### PR DESCRIPTION
Adapt to changed Zope 4 broser:view semantics. We either need a template ZCML argument or a __call__ method on the class.