### PR TITLE
Display document byline viewlet only to anonymous users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 Incompatibilities:
 
-- Deprecated ``plone.app.layout.globals.pattern_settings``. 
+- Deprecated ``plone.app.layout.globals.pattern_settings``.
   Moved view to ``Products.CMFPlone.patterns.view``.
   Deprecated also pointless interface for this view.
   Addresses https://github.com/plone/Products.CMFPlone/issues/1513 and goes together with https://github.com/plone/Products.CMFPlone/issues/1514.
@@ -17,6 +17,9 @@ New:
 - *add item here*
 
 Fixes:
+
+- Document byline viewlet is now displayed only to anonymous users if permited by the `Allow anyone to view 'about' information` option in the `Security Settings` of `Site Setup` (closes `CMFPlone#1556`_).
+  [hvelarde]
 
 - Fix body class ``pat-markspeciallinks`` not set.
   Fixes #84.
@@ -1708,3 +1711,4 @@ Fixes:
 .. _`CMFPlone#1037`: https://github.com/plone/Products.CMFPlone/issues/1037
 .. _`CMFPlone#1151`: https://github.com/plone/Products.CMFPlone/issues/1151
 .. _`CMFPlone#1178`: https://github.com/plone/Products.CMFPlone/issues/1178
+.. _`CMFPlone#1556`: https://github.com/plone/Products.CMFPlone/issues/1556

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ New:
 Fixes:
 
 - Document byline viewlet is now displayed only to anonymous users if permited by the `Allow anyone to view 'about' information` option in the `Security Settings` of `Site Setup` (closes `CMFPlone#1556`_).
+  Code used to show the lock status and history view was removed from the document byline as this information was not available to anonymous users anyway.
   [hvelarde]
 
 - Fix body class ``pat-markspeciallinks`` not set.

--- a/plone/app/layout/viewlets/content.py
+++ b/plone/app/layout/viewlets/content.py
@@ -73,42 +73,6 @@ class DocumentBylineViewlet(ViewletBase):
         )
         return self.anonymous and settings.allow_anon_views_about
 
-    def show_history(self):
-        has_access_preview_versions_permission = _checkPermission(
-            'CMFEditions: Access previous versions',
-            self.context
-        )
-        if not has_access_preview_versions_permission:
-            return False
-        if IViewView.providedBy(self.__parent__):
-            return True
-        if IFolderContentsView.providedBy(self.__parent__):
-            return True
-        return False
-
-    def locked_icon(self):
-        if not getSecurityManager().checkPermission('Modify portal content',
-                                                    self.context):
-            return ""
-
-        locked = False
-        lock_info = queryMultiAdapter((self.context, self.request),
-                                      name='plone_lock_info')
-        if lock_info is not None:
-            locked = lock_info.is_locked()
-        else:
-            context = aq_inner(self.context)
-            lockable = getattr(
-                context.aq_explicit, 'wl_isLocked', None) is not None
-            locked = lockable and context.wl_isLocked()
-
-        if not locked:
-            return ""
-
-        portal = self.portal_state.portal()
-        icon = portal.restrictedTraverse('lock_icon.png')
-        return icon.tag(title='Locked')
-
     def creator(self):
         return self.context.Creator()
 

--- a/plone/app/layout/viewlets/content.py
+++ b/plone/app/layout/viewlets/content.py
@@ -71,7 +71,7 @@ class DocumentBylineViewlet(ViewletBase):
             ISecuritySchema,
             prefix='plone',
         )
-        return not self.anonymous or settings.allow_anon_views_about
+        return self.anonymous and settings.allow_anon_views_about
 
     def show_history(self):
         has_access_preview_versions_permission = _checkPermission(

--- a/plone/app/layout/viewlets/document_byline.pt
+++ b/plone/app/layout/viewlets/document_byline.pt
@@ -2,12 +2,6 @@
      id="plone-document-byline"
      i18n:domain="plone"
      tal:condition="view/show">
-  <span id="lock-icon"
-        tal:define="lock_icon view/locked_icon"
-        tal:condition="python:lock_icon">
-      <img tal:replace="structure lock_icon" />
-  </span>
-
   <tal:creator tal:define="creator_short_form view/creator;"
                tal:condition="creator_short_form">
   <tal:name tal:define="creator_long_form string:?author=${creator_short_form};
@@ -57,14 +51,6 @@
     <span class="state-expired"
           i18n:translate="time_expired">expired</span>
   </tal:expired>
-
-  <span class="contentHistory" id="content-history"
-        tal:condition="view/show_history">
-    —
-    <a href="#"
-       tal:attributes="href string:${here/absolute_url}/@@historyview"
-       i18n:translate="label_history">History</a>
-  </span>
 
   <div class="documentContributors"
        tal:define="contributors context/Contributors"

--- a/plone/app/layout/viewlets/tests/test_content.py
+++ b/plone/app/layout/viewlets/tests/test_content.py
@@ -50,23 +50,6 @@ class TestDocumentBylineViewletView(ViewletsTestCase):
         viewlet.update()
         return viewlet
 
-    def test_anonymous_locked_icon(self):
-        viewlet = self._get_viewlet()
-        ILockable(self.context).lock()
-        self.logout()
-        viewlet = self._get_viewlet()
-        self.assertEqual(viewlet.locked_icon(), '')
-
-    def test_locked_icon(self):
-        viewlet = self._get_viewlet()
-        self.assertEqual(viewlet.locked_icon(), "")
-        ILockable(self.context).lock()
-        lockIconUrl = (
-            '<img src="http://nohost/plone/lock_icon.png" alt="" '
-            'title="Locked" height="16" width="16" />'
-        )
-        self.assertEqual(viewlet.locked_icon(), lockIconUrl)
-
     def test_pub_date(self):
         # configure our portal to enable publication date on pages globally on
         # the site


### PR DESCRIPTION
Also, clean up the document byline code to remove unnecessary code.