### PR TITLE
Rework sitemap.xml.gz view to fix it for plone.app.multilingual [2.5.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,11 @@ Fixes:
 
 - Fixed html validation: element nav does not need a role attribute.
   [maurits]
+Fixes:
+
+- Rework sitemap.xml.gz to allow filtering of sitemap elements; and supply such
+  a filter if LinguaPlone is installed.
+  [djowett]
 
 - Fixed invalid html of social viewlet by moving the schema.org tags
   to the body in a new viewlet ``plone.abovecontenttitle.socialtags``

--- a/plone/app/layout/sitemap/configure.zcml
+++ b/plone/app/layout/sitemap/configure.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:browser="http://namespaces.zope.org/browser">
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
 
   <browser:page
       name="sitemap.xml.gz"
@@ -8,5 +9,15 @@
       class=".sitemap.SiteMapView"
       permission="zope2.Public"
      />
+
+  <configure zcml:condition="installed Products.LinguaPlone">
+      <browser:page
+          name="sitemap.xml.gz"
+          for="plone.app.layout.navigation.interfaces.INavigationRoot"
+          class=".sitemap.LinguaPloneSiteMapView"
+          permission="zope2.Public"
+          layer="Products.LinguaPlone.interfaces.ILinguaPloneProductLayer"
+         />
+  </configure>
 
 </configure>

--- a/plone/app/layout/sitemap/sitemap.py
+++ b/plone/app/layout/sitemap/sitemap.py
@@ -56,7 +56,10 @@ class SiteMapView(BrowserView):
 
         query['is_default_page'] = True
         default_page_modified = OOBTree()
-        for item in catalog.searchResults(query, Language='all'):
+
+        keywords = self.extra_search_parameters()
+        
+        for item in catalog.searchResults(query, **keywords):
             key = item.getURL().rsplit('/', 1)[0]
             value = (item.modified.micros(), item.modified.ISO8601())
             default_page_modified[key] = value
@@ -80,7 +83,8 @@ class SiteMapView(BrowserView):
             }
 
         query['is_default_page'] = False
-        for item in catalog.searchResults(query, Language='all'):
+
+        for item in catalog.searchResults(query, **keywords):
             loc = item.getURL()
             date = item.modified
             # Comparison must be on GMT value
@@ -121,3 +125,22 @@ class SiteMapView(BrowserView):
         self.request.response.setHeader('Content-Type',
                                         'application/octet-stream')
         return self.generate()
+        
+    def extra_search_parameters(self):
+        """Allows extra filtering of the sitemap 
+        for use (in particular) by LinguaPlone
+        
+        :returns: a dictionary of keyword parameters to pass into 
+        catalog.searchResults()
+        """
+        return {}
+
+
+class LinguaPloneSiteMapView(SiteMapView):
+    """Overrides SiteMapView with patch for LinguaPlone
+    """
+
+    def extra_search_parameters(self):
+        """Work around LinguaPlone's catalog patch."""
+        # see https://github.com/plone/Products.LinguaPlone/blob/master/Products/LinguaPlone/catalog.py
+        return {'Language':'all'}


### PR DESCRIPTION
This parallels #92 on 2.3.x branch

Some code here assumes that LinguaPlone or PAM 1.x might at some point use this version of plone.app.layout - if that is not true, because they are always going to be on other branches, then it could be radically simplified.  If you know - let me know! 