### PR TITLE
Fix sitemap.xml.gz for plone.app.multilingual (>= 2.x) 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,11 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Fix sitemap.xml.gz for plone.app.multilingual (>= 2.x) but breaks it for 
+  LinguaPlone and plone.app.multilingual 1.x
+  If this is a problem then please see bedbfeb67 on 2.5.x branch for how to 
+  maintain compatibility with these products.
+  [djowett]
 
 New features:
 

--- a/plone/app/layout/sitemap/sitemap.py
+++ b/plone/app/layout/sitemap/sitemap.py
@@ -54,7 +54,7 @@ class SiteMapView(BrowserView):
 
         query['is_default_page'] = True
         default_page_modified = OOBTree()
-        for item in catalog.searchResults(query, Language='all'):
+        for item in catalog.searchResults(query):
             key = item.getURL().rsplit('/', 1)[0]
             value = (item.modified.micros(), item.modified.ISO8601())
             default_page_modified[key] = value
@@ -78,7 +78,7 @@ class SiteMapView(BrowserView):
             }
 
         query['is_default_page'] = False
-        for item in catalog.searchResults(query, Language='all'):
+        for item in catalog.searchResults(query):
             loc = item.getURL()
             date = item.modified
             # Comparison must be on GMT value


### PR DESCRIPTION
but breaks it for LinguaPlone and PAM 1.x

Similar to #92 on 2.3.x branch, but this is for master branch and Plone 5.1