### PR TITLE
Fix error in viewlet when related dexterity item has been deleted. [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix error in viewlet when related dexterity item has been deleted.
+  [maurits]
 
 
 2.6.3 (2016-12-30)

--- a/plone/app/layout/viewlets/content.py
+++ b/plone/app/layout/viewlets/content.py
@@ -305,6 +305,10 @@ class ContentRelatedItems(ViewletBase):
         brains = []
         for r in related:
             path = r.to_path
+            if path is None:
+                # Item was deleted.  The related item should have been cleaned
+                # up, but apparently this does not happen.
+                continue
             # the query will return an empty list if the user
             # has no permission to see the target object
             brains.extend(catalog(path=dict(query=path, depth=0)))

--- a/plone/app/layout/viewlets/tests/test_content.py
+++ b/plone/app/layout/viewlets/tests/test_content.py
@@ -187,6 +187,15 @@ class TestRelatedItemsViewlet(ViewletsTestCase):
         self.assertEqual([x.Title for x in related], [
                          'Document 2', 'Document 3'])
 
+    def testDeletedRelatedItems(self):
+        # Deleted related items should not cause problems.
+        self.folder._delObject('doc2')
+        request = self.app.REQUEST
+        viewlet = ContentRelatedItems(self.folder.doc1, request, None, None)
+        viewlet.update()
+        related = viewlet.related_items()
+        self.assertEqual([x.Title for x in related], ['Document 3'])
+
 
 class TestDexterityRelatedItemsViewlet(ViewletsTestCase):
 
@@ -263,3 +272,12 @@ class TestDexterityRelatedItemsViewlet(ViewletsTestCase):
         viewlet.update()
         related = viewlet.related_items()
         self.assertEqual(len(related), 1)
+
+    def testDexterityDeletedRelatedItems(self):
+        # Deleted related items should not cause problems.
+        self.folder._delObject('doc1')
+        request = self.app.REQUEST
+        viewlet = ContentRelatedItems(self.folder.dex1, request, None, None)
+        viewlet.update()
+        related = viewlet.related_items()
+        self.assertEqual([x.id for x in related], ['doc2'])


### PR DESCRIPTION
With Archetypes all is apparently well, but not with dexterity.

Scenario:
- Plone 5.1
- Add Page 1.
- Add Page 2, with Page 1 as related item.
- Page 1 is shown in the related items viewlet.
- Delete Page 1.
- Page 2 can be viewed, but there is an error in the related items viewlet.
- Luckily you can edit Page 2 and save without changing anything, and the missing related item is cleaned up and the error is gone.

```
ERROR plone.app.viewletmanager Error while rendering viewlet-manager=plone.belowcontentbody, viewlet=plone.belowcontentbody.relateditems
Traceback (most recent call last):
  File "/Users/maurits/shared-eggs/plone.app.viewletmanager-2.0.10-py2.7.egg/plone/app/viewletmanager/manager.py", line 112, in render
    html.append(viewlet.render())
  File "/Users/maurits/shared-eggs/plone.app.layout-2.5.20-py2.7.egg/plone/app/layout/viewlets/common.py", line 60, in render
    return self.index()
  File "/Users/maurits/shared-eggs/Zope2-2.13.24-py2.7.egg/Products/Five/browser/pagetemplatefile.py", line 125, in __call__
    return self.im_func(im_self, *args, **kw)
  File "/Users/maurits/shared-eggs/Zope2-2.13.24-py2.7.egg/Products/Five/browser/pagetemplatefile.py", line 59, in __call__
    sourceAnnotations=getattr(debug_flags, 'sourceAnnotations', 0),
  File "/Users/maurits/shared-eggs/zope.pagetemplate-3.6.3-py2.7.egg/zope/pagetemplate/pagetemplate.py", line 132, in pt_render
    strictinsert=0, sourceAnnotations=sourceAnnotations
  File "/Users/maurits/shared-eggs/five.pt-2.2.4-py2.7.egg/five/pt/engine.py", line 98, in __call__
    return self.template.render(**kwargs)
  File "/Users/maurits/shared-eggs/z3c.pt-3.0.0a1-py2.7.egg/z3c/pt/pagetemplate.py", line 163, in render
    return base_renderer(**context)
  File "/Users/maurits/shared-eggs/Chameleon-2.24-py2.7.egg/chameleon/zpt/template.py", line 261, in render
    return super(PageTemplate, self).render(**vars)
  File "/Users/maurits/shared-eggs/Chameleon-2.24-py2.7.egg/chameleon/template.py", line 191, in render
    raise_with_traceback(exc, tb)
  File "/Users/maurits/shared-eggs/Chameleon-2.24-py2.7.egg/chameleon/template.py", line 171, in render
    self._render(stream, econtext, rcontext)
  File "1b01122f170c0e8b6d81719c8911d884.py", line 101, in render
  File "/Users/maurits/shared-eggs/five.pt-2.2.4-py2.7.egg/five/pt/expressions.py", line 161, in __call__
    return base()
  File "/Users/maurits/shared-eggs/plone.app.layout-2.5.20-py2.7.egg/plone/app/layout/viewlets/content.py", line 323, in related_items
    res = self.related2brains(related)
  File "/Users/maurits/shared-eggs/plone.app.layout-2.5.20-py2.7.egg/plone/app/layout/viewlets/content.py", line 342, in related2brains
    brains.extend(catalog(path=dict(query=path, depth=0)))
  File "/Users/maurits/shared-eggs/Products.CMFPlone-5.0.6-py2.7.egg/Products/CMFPlone/CatalogTool.py", line 390, in searchResults
    return ZCatalog.searchResults(self, REQUEST, **kw)
  File "/Users/maurits/shared-eggs/Products.ZCatalog-3.0.2-py2.7.egg/Products/ZCatalog/ZCatalog.py", line 604, in searchResults
    return self._catalog.searchResults(REQUEST, used, **kw)
  File "/Users/maurits/shared-eggs/Products.ZCatalog-3.0.2-py2.7.egg/Products/ZCatalog/Catalog.py", line 1072, in searchResults
    return self.search(args, sort_indexes, reverse, sort_limit, _merge)
  File "/Users/maurits/shared-eggs/Products.ZCatalog-3.0.2-py2.7.egg/Products/ZCatalog/Catalog.py", line 549, in search
    r = _apply_index(query, rs)
  File "/Users/maurits/shared-eggs/Products.ExtendedPathIndex-3.1.1-py2.7.egg/Products/ExtendedPathIndex/ExtendedPathIndex.py", line 353, in _apply_index
    resultset=resultset)
  File "/Users/maurits/shared-eggs/Products.ExtendedPathIndex-3.1.1-py2.7.egg/Products/ExtendedPathIndex/ExtendedPathIndex.py", line 210, in search
    level = int(path[1])
TypeError: 'NoneType' object has no attribute '__getitem__'

 - Expression: "view/related_items"
 - Filename:   ... 7.egg/plone/app/layout/viewlets/document_relateditems.pt
 - Location:   (line 3: col 25)
 - Source:     tal:define="related view/related_items"
                                   ^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: {...} (0)
               template: <ViewPageTemplateFile - at 0x113f4ebd0>
               views: <ViewMapper - at 0x113f4eb10>
               modules: <instance - at 0x10cd618c0>
               args: <tuple - at 0x10c280050>
               here: <ImplicitAcquisitionWrapper django at 0x111c7e960>
               user: <ImplicitAcquisitionWrapper - at 0x111c86140>
               nothing: <NoneType - at 0x10c1d1ea8>
               container: <ImplicitAcquisitionWrapper django at 0x111c7e960>
               request: <instance - at 0x11260b440>
               wrapped_repeat: <SafeMapping - at 0x112bd09f0>
               traverse_subpath: <list - at 0x111f84368>
               default: <object - at 0x10c2d6c10>
               loop: {...} (0)
               context: <ImplicitAcquisitionWrapper django at 0x111c7e960>
               view: <ContentRelatedItems plone.belowcontentbody.relateditems at 0x10ceb5050>
               translate: <function translate at 0x114320848>
               root: <ImplicitAcquisitionWrapper Zope at 0x111ae5cd0>
               options: {...} (0)
               target_language: nl
```

So related items are not correctly cleaned up. That is a bigger problem, but I think we already knew that.
This pull request fixes the most immediately visible effect of this.
