### PR TITLE
Fix error in viewlet when related dexterity item has been deleted. [2.3.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix error in viewlet when related dexterity item has been deleted.
+  [maurits]
 
 
 2.3.16 (2016-12-19)

--- a/plone/app/layout/viewlets/content.py
+++ b/plone/app/layout/viewlets/content.py
@@ -176,6 +176,10 @@ class ContentRelatedItems(ViewletBase):
         brains = []
         for r in related:
             path = r.to_path
+            if path is None:
+                # Item was deleted.  The related item should have been cleaned
+                # up, but apparently this does not happen.
+                continue
             # the query will return an empty list if the user has no
             # permission to see the target object
             brains.extend(catalog(path=dict(query=path, depth=0)))

--- a/plone/app/layout/viewlets/tests/test_content.py
+++ b/plone/app/layout/viewlets/tests/test_content.py
@@ -106,6 +106,15 @@ class TestRelatedItemsViewlet(ViewletsTestCase):
         related = viewlet.related_items()
         self.assertEqual([x.Title for x in related], ['Document 2', 'Document 3'])
 
+    def testDeletedRelatedItems(self):
+        # Deleted related items should not cause problems.
+        self.folder._delObject('doc2')
+        request = self.app.REQUEST
+        viewlet = ContentRelatedItems(self.folder.doc1, request, None, None)
+        viewlet.update()
+        related = viewlet.related_items()
+        self.assertEqual([x.Title for x in related], ['Document 3'])
+
 
 class TestDexterityRelatedItemsViewlet(ViewletsTestCase):
 
@@ -173,6 +182,15 @@ class TestDexterityRelatedItemsViewlet(ViewletsTestCase):
         viewlet.update()
         related = viewlet.related_items()
         self.assertEqual(len(related), 1)
+
+    def testDexterityDeletedRelatedItems(self):
+        # Deleted related items should not cause problems.
+        self.folder._delObject('doc1')
+        request = self.app.REQUEST
+        viewlet = ContentRelatedItems(self.folder.dex1, request, None, None)
+        viewlet.update()
+        related = viewlet.related_items()
+        self.assertEqual([x.id for x in related], ['doc2'])
 
 
 def test_suite():


### PR DESCRIPTION
Backport from #112