### PR TITLE
Remove redundant Twitter card tags.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,8 @@ Bug fixes:
 
 - Remove redundant Twitter card tags. If og:title, og:description, og:image and
   og:url are defined Twitter will recognise and use those on the card.
-  See: https://dev.twitter.com/cards/getting-started section on
-  Twitter Cards and Open Graph. fixes #119.
+  See: `Twitter getting started <https://dev.twitter.com/cards/getting-started>`_ section on
+  Twitter Cards and Open Graph. Fixes `issue 119 <https://github.com/plone/plone.app.layout/issues/119>`_.
   [jladage]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,12 @@ Bug fixes:
 - Fix import location for Products.ATContentTypes.interfaces.
   [thet]
 
+- Remove redundant Twitter card tags. If og:title, og:description and
+  og:url are defined Twitter will recognise and use those on the card.
+  See: https://dev.twitter.com/cards/getting-started section on
+  Twitter Cards and Open Graph.
+  [jladage]
+
 
 2.6.4 (2017-01-17)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Bug fixes:
 - Remove redundant Twitter card tags. If og:title, og:description and
   og:url are defined Twitter will recognise and use those on the card.
   See: https://dev.twitter.com/cards/getting-started section on
-  Twitter Cards and Open Graph.
+  Twitter Cards and Open Graph. fixes #119.
   [jladage]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Bug fixes:
 - Fix import location for Products.ATContentTypes.interfaces.
   [thet]
 
-- Remove redundant Twitter card tags. If og:title, og:description and
+- Remove redundant Twitter card tags. If og:title, og:description, og:image and
   og:url are defined Twitter will recognise and use those on the card.
   See: https://dev.twitter.com/cards/getting-started section on
   Twitter Cards and Open Graph. fixes #119.

--- a/plone/app/layout/viewlets/social.py
+++ b/plone/app/layout/viewlets/social.py
@@ -46,7 +46,6 @@ class SocialTagsViewlet(TitleViewlet):
         tags = [
             dict(itemprop="name", content=self.page_title),
             dict(name="twitter:card", content="summary"),
-            dict(name="twitter:title", content=self.page_title),
             dict(property="og:site_name", content=self.site_title_setting),
             dict(property="og:title", content=self.page_title),
             dict(property="og:type", content="website"),
@@ -74,8 +73,6 @@ class SocialTagsViewlet(TitleViewlet):
         tags.extend([
             dict(itemprop="description", content=item.description),
             dict(itemprop="url", content=item.link),
-            dict(name="twitter:description", content=item.description),
-            dict(name="twitter:url", content=item.link),
             dict(property="og:description", content=item.description),
             dict(property="og:url", content=item.link),
         ])
@@ -85,7 +82,6 @@ class SocialTagsViewlet(TitleViewlet):
             if item.file_type.startswith('image'):
                 found_image = True
                 tags.extend([
-                    dict(name="twitter:image", content=item.file_url),
                     dict(property="og:image", content=item.file_url),
                     dict(itemprop="image", content=item.file_url),
                     dict(property="og:image:type", content=item.file_type)
@@ -105,7 +101,6 @@ class SocialTagsViewlet(TitleViewlet):
         if not found_image:
             url = getSiteLogo()
             tags.extend([
-                dict(name="twitter:image", content=url),
                 dict(property="og:image", content=url),
                 dict(itemprop="image", content=url),
                 dict(property="og:image:type", content='image/png')

--- a/plone/app/layout/viewlets/tests/test_social.py
+++ b/plone/app/layout/viewlets/tests/test_social.py
@@ -47,7 +47,7 @@ class TestSocialViewlet(ViewletsTestCase):
         self.assertTrue(self.tagFound(
             viewlet, 'property', 'og:site_name', viewlet.site_title_setting))
         self.assertTrue(self.tagFound(
-            viewlet, 'name', 'og:title', viewlet.page_title))
+            viewlet, 'property', 'og:title', viewlet.page_title))
         self.assertTrue(self.tagFound(
             viewlet, 'property', 'og:description', description))
         self.assertTrue(self.tagFound(

--- a/plone/app/layout/viewlets/tests/test_social.py
+++ b/plone/app/layout/viewlets/tests/test_social.py
@@ -43,8 +43,6 @@ class TestSocialViewlet(ViewletsTestCase):
         # Twitter
         self.assertTrue(self.tagFound(
             viewlet, 'name', 'twitter:card', "summary"))
-        self.assertTrue(self.tagFound(
-            viewlet, 'name', 'twitter:url', folder_url))
         # OpenGraph/Facebook
         self.assertTrue(self.tagFound(
             viewlet, 'property', 'og:site_name', viewlet.site_title_setting))

--- a/plone/app/layout/viewlets/tests/test_social.py
+++ b/plone/app/layout/viewlets/tests/test_social.py
@@ -44,14 +44,12 @@ class TestSocialViewlet(ViewletsTestCase):
         self.assertTrue(self.tagFound(
             viewlet, 'name', 'twitter:card', "summary"))
         self.assertTrue(self.tagFound(
-            viewlet, 'name', 'twitter:title', viewlet.page_title))
-        self.assertTrue(self.tagFound(
-            viewlet, 'name', 'twitter:description', description))
-        self.assertTrue(self.tagFound(
             viewlet, 'name', 'twitter:url', folder_url))
         # OpenGraph/Facebook
         self.assertTrue(self.tagFound(
             viewlet, 'property', 'og:site_name', viewlet.site_title_setting))
+        self.assertTrue(self.tagFound(
+            viewlet, 'name', 'og:title', viewlet.page_title))
         self.assertTrue(self.tagFound(
             viewlet, 'property', 'og:description', description))
         self.assertTrue(self.tagFound(
@@ -108,8 +106,6 @@ class TestSocialViewlet(ViewletsTestCase):
         viewlet.update()
         self.assertTrue(self.tagFound(
             viewlet, 'property', 'og:image', 'http://nohost/plone/logo.png'))
-        self.assertTrue(self.tagFound(
-            viewlet, 'name', 'twitter:image', 'http://nohost/plone/logo.png'))
         self.assertFalse(self.tagFound(viewlet, 'itemprop'))
         self.assertTrue(self.bodyTagFound(
             viewlet, 'itemprop', 'image', 'http://nohost/plone/logo.png'))


### PR DESCRIPTION
If `og:title`, `og:description` and `og:url` are defined Twitter will recognise and use those on the card.
See: https://dev.twitter.com/cards/getting-started section on Twitter Cards and Open Graph.