### PR TITLE
fixes https://github.com/plone/Products.CMFPlone/issues/1619

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Put "search in this section" checkbox where assistive tech users have a fair chance of finding and using it
+  https://github.com/plone/Products.CMFPlone/issues/1619
+  [polyester]
 
 
 2.7.1 (2017-07-03)

--- a/plone/app/layout/viewlets/searchbox.pt
+++ b/plone/app/layout/viewlets/searchbox.pt
@@ -13,7 +13,22 @@
         <label class="hiddenStructure"
                for="searchGadget"
                i18n:translate="text_search">Search Site</label>
-
+             
+        <div class="searchSection">
+            <input id="searchbox_currentfolder_only"
+                   class="noborder"
+                   type="checkbox"
+                   name="path"
+                   tal:attributes="value view/folder_path;
+                                   checked request/form/path|nothing"
+                   />
+            <label for="searchbox_currentfolder_only"
+                   i18n:translate="label_searchbox_currentfolder_only"
+                   style="cursor: pointer">
+                only in current section
+            </label>
+        </div>
+             
         <input name="SearchableText"
                type="text"
                size="18"
@@ -31,21 +46,7 @@
                value="Search"
                i18n:attributes="value label_search;" />
 
-        <div class="searchSection">
-            <input id="searchbox_currentfolder_only"
-                   class="noborder"
-                   type="checkbox"
-                   name="path"
-                   tal:attributes="value view/folder_path;
-                                   checked request/form/path|nothing"
-                   />
-            <label for="searchbox_currentfolder_only"
-                   i18n:translate="label_searchbox_currentfolder_only"
-                   style="cursor: pointer">
-                only in current section
-            </label>
-        </div>
-        </div>
+         </div>
     </form>
 
     <div id="portal-advanced-search"


### PR DESCRIPTION
because of https://www.w3.org/TR/WCAG20-TECHS/C27.html the 'only in this section' part should not be displayed after the input field, as in original issue description. 

I'll also make a change in Barcelonetta to align the tick box and the text properly, but that's independent of this change.