### PR TITLE
Introduce IBodyClassAdapter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Breaking changes:
 
 New features:
 
+- Allow addition of extra body classes via multiple IBodyClassAdapter adapter registrations without the need to overload the ILayoutPolicy view.
+  [thet, jensens, agitator]
+
 - Make it easier to override seperator in title viewlet
   [tomgross]
 
@@ -18,13 +21,8 @@ Bug fixes:
 - More py3 fixes.
   [pbauer]
 
-- Use ``get_installer`` in tests.  [maurits]
-
-- Imports are Python3 compatible
-  [ale-rt, jensens]
-
-- Fix for situations where pathbar viewlet variables were undefined in toolbar context
-  [tomgross]
+- Use ``get_installer`` in tests.
+  [maurits]
 
 2.7.5 (2017-11-26)
 ------------------
@@ -36,6 +34,8 @@ New features:
 
 - Imports are Python3 compatible
   [ale-rt, jensens]
+
+Bug fixes:
 
 - Fix for situations where pathbar viewlet variables were undefined in toolbar context
   [tomgross]
@@ -72,6 +72,9 @@ New features:
 
 - Added membertools viewlet. If user is not anonymous and toolbar is not visible according to ``is_toolbar_visible`` the viewlet will show at the location of anontools.
   [agitator]
+- Allow addition of extra body classes via multiple ``IBodyClassAdapter`` adapter registrations without the need to overload the ILayoutPolicy view.
+  RFC / DRAFT / WORK IN PROGRESS
+  [thet]
 
 Bug fixes:
 

--- a/plone/app/layout/globals/interfaces.py
+++ b/plone/app/layout/globals/interfaces.py
@@ -282,6 +282,11 @@ class IViewView(Interface):
     """
 
 
+class IBodyClassAdapter(Interface):
+    """Adapter interface for retrieving extra body classes.
+    """
+
+
 class IPatternsSettingsRenderer(Interface):
     """ Interface for the adapter that renders the settings for patterns
 


### PR DESCRIPTION
Allow addition of extra body classes via multiple ``IBodyClassAdapter`` adapter registrations without the need to overload the ILayoutPolicy view.

RFC / DRAFT / WORK IN PROGRESS

This came out of a wrong presumption that plone.app.mosaic overloads the ILayoutPolicy view, which it doesn't. I solved the original problem by overloading the ILayoutPolicy view myself, but still this is a bit wonky. IMO only integration packages should be allowed to overload ILayoutPolicy, but you cannot control it. Also, sometimes other packages just need to add some body classes, which isn't possible yet without overloading or plone.app.transformchain tricks (as plone.app.mosic is doing).

This PR would solve that.

I need some feedback about this:

- Do we want another adapter to solve this problem?
- Do we want the interface definition in plone.app.layout.globals.interfaces or better Products.CMFPlone.interfaces? (I would prefer the second, but there is yet no good module to add it to).
- I would also provide the default body classes via an default IBodyClassAdapter. But our default body classes need some extra parameters: template and view. I would prefer to not pass these parameters into all generic IBodyClassAdapters. Part of ``bodyClass`` can still be factored out.
- The _toolbar_classes might also better go into a default IBodyClassAdapter. Do we need to deprecate this method, is is supposed to be "internal" (_toolbar_classes)?
- Is the adapter naming good enough?
