### PR TITLE
Use the site-title in the meta-attribute title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Use the site-title in the meta-attribute title unless the navigation_root is not the portal.
+  Fixes https://github.com/plone/Products.CMFPlone/issues/2117
+  [pbauer]
 
 
 2.7.3 (2017-08-27)

--- a/plone/app/layout/viewlets/common.py
+++ b/plone/app/layout/viewlets/common.py
@@ -113,8 +113,11 @@ class TitleViewlet(ViewletBase):
             return
         portal_state = getMultiAdapter((self.context, self.request),
                                        name=u'plone_portal_state')
-        portal_title = escape(safe_unicode(portal_state
-                                           .navigation_root_title()))
+        if IPloneSiteRoot.providedBy(portal_state.navigation_root()):
+            portal_title = self.site_title_setting
+        else:
+            portal_title = escape(
+                safe_unicode(portal_state.navigation_root_title()))
         if self.page_title == portal_title:
             self.site_title = portal_title
         else:

--- a/plone/app/layout/viewlets/tests/test_common.py
+++ b/plone/app/layout/viewlets/tests/test_common.py
@@ -105,7 +105,43 @@ class TestTitleViewsViewlet(ViewletsTestCase):
         except AttributeError:
             pass
 
-    def test_title_viewlet(self):
+    def test_title_viewlet_on_portal(self):
+        """Title viewlet renders navigation root title
+        """
+        self._invalidateRequestMemoizations()
+        self.loginAsPortalOwner()
+        self.app.REQUEST['ACTUAL_URL'] = self.portal.absolute_url()
+        viewlet = TitleViewlet(self.portal, self.app.REQUEST, None)
+        viewlet.update()
+        self.assertEqual(viewlet.site_title, 'Plone site')
+        registry = getUtility(IRegistry)
+        site_settings = registry.forInterface(
+            ISiteSchema, prefix='plone', check=False)
+        site_settings.site_title = u'Süper Site'
+        self._invalidateRequestMemoizations()
+        viewlet.update()
+        self.assertEqual(viewlet.site_title, u'S\xfcper Site')
+
+    def test_title_viewlet_on_content(self):
+        """Title viewlet renders navigation root title
+        """
+        self._invalidateRequestMemoizations()
+        self.loginAsPortalOwner()
+        self.app.REQUEST['ACTUAL_URL'] = self.folder.test.absolute_url()
+        viewlet = TitleViewlet(self.folder.test, self.app.REQUEST, None)
+        viewlet.update()
+        self.assertEqual(viewlet.site_title,
+                         'Test default page &mdash; Plone site')
+        registry = getUtility(IRegistry)
+        site_settings = registry.forInterface(
+            ISiteSchema, prefix="plone", check=False)
+        site_settings.site_title = u'Süper Site'
+        self._invalidateRequestMemoizations()
+        viewlet.update()
+        self.assertEqual(viewlet.site_title,
+                         u'Test default page &mdash; S\xfcper Site')
+
+    def test_title_viewlet_with_navigation_root(self):
         """Title viewlet renders navigation root title
         """
         self._invalidateRequestMemoizations()
@@ -115,7 +151,7 @@ class TestTitleViewsViewlet(ViewletsTestCase):
         viewlet = TitleViewlet(self.folder.test, self.app.REQUEST, None)
         viewlet.update()
         self.assertEqual(viewlet.site_title,
-                         "Test default page &mdash; Folder")
+                         u'Test default page &mdash; Folder')
 
     def test_title_viewlet_in_portal_factory(self):
         """Title viewlet renders navigation root title in portal factory


### PR DESCRIPTION
... unless the navigation_root is not the portal.

Fixes https://github.com/plone/Products.CMFPlone/issues/2117