### PR TITLE
Toolbar related fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Toolbar: Use pattern variavbles to configure the toolbar and submenu widths from plone.lessvariables.
+  [thet]
 
 Bug fixes:
 

--- a/plone/app/layout/viewlets/toolbar.pt
+++ b/plone/app/layout/viewlets/toolbar.pt
@@ -3,7 +3,7 @@
                      personal_bar python: view.get_personal_bar()"
          tal:condition="context_state/is_toolbar_visible"
          i18n:domain="plone">
-  <div id="edit-zone" role="toolbar" class="pat-toolbar">
+  <div id="edit-zone" role="toolbar" class="pat-toolbar" data-pat-toolbar="${view/get_options}">
     <div class="plone-toolbar-container">
       <a class="plone-toolbar-logo">
         <img alt="Plone Toolbar" tal:attributes="src view/get_toolbar_logo" />

--- a/plone/app/layout/viewlets/toolbar.py
+++ b/plone/app/layout/viewlets/toolbar.py
@@ -8,6 +8,8 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 
+import json
+
 
 class ToolbarViewletManager(OrderedViewletManager):
     custom_template = ViewPageTemplateFile('toolbar.pt')
@@ -33,6 +35,25 @@ class ToolbarViewletManager(OrderedViewletManager):
             (self.context, self.request),
             name='plone_portal_state'
         )
+
+    def get_options(self):
+        registry = getUtility(IRegistry)
+        options = {}
+
+        lessvars = registry.get('plone.lessvariables', {})
+
+        toolbar_width = lessvars.get('plone-left-toolbar-expanded', None)
+        submenu_width = lessvars.get('plone-toolbar-submenu-width', None)
+        desktop_width = lessvars.get('plone-screen-sm-min', None)
+
+        if toolbar_width:
+            options['toolbar_width'] = toolbar_width
+        if submenu_width:
+            options['submenu_width'] = submenu_width
+        if desktop_width:
+            options['desktop_width'] = desktop_width
+
+        return json.dumps(options)
 
     def get_personal_bar(self):
         viewlet = PersonalBarViewlet(


### PR DESCRIPTION
-  Toolbar: Use pattern variavbles to configure the toolbar and submenu widths from plone.lessvariables.

Merge together:
https://github.com/plone/Products.CMFPlone/pull/2165
https://github.com/plone/plone.app.layout/pull/133