### PR TITLE
Do not use 'rel="tag"' attribute on the keywords viewlet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ New features:
 
 Bug fixes:
 
+- Do not use ``rel="tag"`` attribute on the keywords viewlet as the referenced document is not a tag definition but a search result;
+  use ``rel="nofollow"`` instead to avoid search crawlers hammering our sites.
+  [hvelarde]
+
 - More py3 fixes.
   [pbauer]
 

--- a/plone/app/layout/viewlets/keywords.pt
+++ b/plone/app/layout/viewlets/keywords.pt
@@ -10,7 +10,7 @@
     <li tal:repeat="category categories">
       <a href=""
          class="link-category"
-         rel="tag"
+         rel="nofollow"
          tal:content="category"
          tal:define="quotedCat python:url_quote(category)"
          tal:attributes="href string:${context/@@plone_portal_state/navigation_root_url}/@@search?Subject%3Alist=${quotedCat}">


### PR DESCRIPTION
The referenced document is not a tag definition but a search result.

Refs. https://www.w3.org/TR/2011/WD-html5-20110113/links.html#link-type-tag