### PR TITLE
re #1801: Reimplement enable_http_compression to replace skin script.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ New features:
 - Add test for Revert to Revision action in History Viewlet
   [davilima6]
 
-- Reimplement enable_http_compression to replace skin script. #1801
+- Remove ``enable_compression`` method that isn't used in Plone. #1801
   [tlotze]
 
 Bug fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New features:
 - Add test for Revert to Revision action in History Viewlet
   [davilima6]
 
+- Reimplement enable_http_compression to replace skin script. #1801
+  [tlotze]
+
 Bug fixes:
 
 - Show document byline for logged-in users. Fixes #160

--- a/plone/app/layout/viewlets/httpheaders.py
+++ b/plone/app/layout/viewlets/httpheaders.py
@@ -22,10 +22,6 @@ class HTTPCachingHeaders(HeaderViewlet):
     """Replace the old global_cache_settings/macros/cacheheaders
     """
 
-    def enable_compression(self):
-        """Call to activate gzip"""
-        self.request.RESPONSE.enableHTTPCompression(REQUEST=self.request)
-
     def getHeaders(self):
         lang = getattr(self.context, 'Language', None)
         if callable(lang):

--- a/plone/app/layout/viewlets/httpheaders.py
+++ b/plone/app/layout/viewlets/httpheaders.py
@@ -24,7 +24,7 @@ class HTTPCachingHeaders(HeaderViewlet):
 
     def enable_compression(self):
         """Call to activate gzip"""
-        self.context.enableHTTPCompression(request=self.request, enable=1)
+        self.request.RESPONSE.enableHTTPCompression(REQUEST=self.request)
 
     def getHeaders(self):
         lang = getattr(self.context, 'Language', None)


### PR DESCRIPTION
Actually, it might be possible to delete the enable_compression method
entirely, it doesn't seem to be used by Plone. I'm just not sure whether
3rd-party code might rely on it even though I think it's unlikely.