### PR TITLE
[a11y] Added role attribute for portalMessage + formatted its template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- a11y: Added role attribute for portalMessage
+  [nzambello]
 
 
 3.0.0 (2018-10-30)

--- a/plone/app/layout/viewlets/globalstatusmessage.pt
+++ b/plone/app/layout/viewlets/globalstatusmessage.pt
@@ -1,12 +1,18 @@
 <tal:statusmsg tal:define="messages view/messages"
-    tal:repeat="message messages">
+               tal:repeat="message messages">
 
-    <div tal:define="mtype message/type | nothing;"
-        tal:attributes="class string:portalMessage ${mtype};">
-        <strong
-            i18n:translate="" tal:content="python:mtype.capitalize()">Info</strong>
+    <div tal:define="mtype message/type | nothing;
+                     mrole python: mtype === 'error' and 'alert' or 'status';"
+         tal:attributes="class string:portalMessage ${mtype};
+                         role mrole;">
+
+        <strong i18n:translate=""
+                tal:content="python:mtype.capitalize()">
+            Info
+        </strong>
         <span class="content"
-            tal:replace="message/message | nothing" i18n:translate="">
+              tal:replace="message/message | nothing"
+              i18n:translate="">
             The status message.
         </span>
     </div>


### PR DESCRIPTION
Screen readers could now see and read correctly alerts/status messages.
I also fixed its template syntax for readabilty and correctness.