### PR TITLE
Fixed test in combination with newer CMFCore.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New features:
 
 Bug fixes:
 
+- Fixed test in combination with newer CMFCore.  [maurits]
+
 - Memory leak on getUserInfo [avoinea] (#204)
 
 

--- a/plone/app/layout/sitemap/tests/test_sitemap.py
+++ b/plone/app/layout/sitemap/tests/test_sitemap.py
@@ -234,10 +234,15 @@ class SiteMapTestCase(PloneTestCase):
             default, 'review_state'))
         self.assertTrue(self.portal.plone_utils.isDefaultPage(default))
 
-        default.modification_date = DateTime("2001-01-01")
-        folder.modification_date = DateTime("2000-01-01")
         self.portal.portal_catalog.reindexObject(folder)
         self.portal.portal_catalog.reindexObject(default)
+        default.modification_date = DateTime("2001-01-01")
+        folder.modification_date = DateTime("2000-01-01")
+        # Note: the modification date is overwritten when you call reindexObject,
+        # which is totally not what we want.  So call it with the relevant index.
+        # This avoids the overwriting.
+        self.portal.portal_catalog.reindexObject(folder, idxs=['modified'])
+        self.portal.portal_catalog.reindexObject(default, idxs=['modified'])
         self.portal.default_page = "published"
         self.portal.portal_catalog.reindexObject(self.portal.published)
         self.logout()
@@ -247,5 +252,6 @@ class SiteMapTestCase(PloneTestCase):
             '<loc>http://nohost/plone/folder/default</loc>' in xml)
         self.assertTrue('<loc>http://nohost/plone/folder</loc>' in xml)
         self.assertTrue('<lastmod>2001-01-01T' in xml)
+        self.assertFalse('<lastmod>2000-01-01T' in xml)
         self.assertTrue('<loc>http://nohost/plone</loc>' in xml)
         self.assertFalse('<loc>http://nohost/plone/published</loc>' in xml)


### PR DESCRIPTION
Plone coredev 5.1 uses CMFCore 2.2.12. But the 2.2 branch has a [fix](https://github.com/zopefoundation/Products.CMFCore/pull/60) which is obviously good, but that causes a test failure in plone.app.layout. See [Jenkins](https://jenkins.plone.org/job/pull-request-5.1/115/testReport/):

```
  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/home/jenkins/workspace/pull-request-5.1/src/plone.app.layout/plone/app/layout/sitemap/tests/test_sitemap.py", line 249, in test_default_pages
    self.assertTrue('<lastmod>2001-01-01T' in xml)
  File "/srv/python2.7/lib/python2.7/unittest/case.py", line 422, in assertTrue
    raise self.failureException(msg)
```

I have fixed the test so it works with both versions of CMFCore.