### PR TITLE
Restore compatibility

### DIFF
--- a/news/227.bugfix
+++ b/news/227.bugfix
@@ -1,0 +1,1 @@
+Restore compatibility with old code that was inheriting from this class and overriding the __init__ method

--- a/plone/app/layout/analytics/view.py
+++ b/plone/app/layout/analytics/view.py
@@ -20,7 +20,6 @@ class AnalyticsViewlet(BrowserView):
         self.request = request
         self.view = view
         self.manager = manager
-        self.webstats_js = ''
 
     def update(self):
         """render the webstats snippet"""
@@ -31,4 +30,4 @@ class AnalyticsViewlet(BrowserView):
             if site_settings.webstats_js:
                 self.webstats_js = site_settings.webstats_js
         except AttributeError:
-            pass
+            self.webstats_js = u""


### PR DESCRIPTION
Restore compatibility with old code that was inheriting from this class and overriding the `__init__` method

Fixes #227
Refs #220