### PR TITLE
Analytics viewlet: make webstats_js a property

### DIFF
--- a/news/227.breaking
+++ b/news/227.breaking
@@ -1,0 +1,1 @@
+Analytics viewlet: make webstats_js a property, so that it does not rely on an a call to the update method to be correctly evaluated [ale-rt]

--- a/news/227.bugfix
+++ b/news/227.bugfix
@@ -1,1 +1,1 @@
-Restore compatibility with old code that was inheriting from this class and overriding the __init__ method
+Analytics viewlet: restore compatibility with old code that was inheriting from this class and overriding the __init__ method [ale-rt]

--- a/plone/app/layout/analytics/tests/analytics.txt
+++ b/plone/app/layout/analytics/tests/analytics.txt
@@ -12,8 +12,21 @@ We need a view on the content.
 Now we can instantiate the manager.
 
     >>> manager = Footer(portal, request, view)
+    >>> manager.update()
+    >>> for viewlet in manager.viewlets:
+    ...     if viewlet.__name__ == "plone.analytics":
+    ...         analytics = viewlet
+    ...         break
 
-Set analytics (webstats_js) code through the controlpanel
+When no analytics (webstats_js) code is set up the viewlet will not be rendered:
+
+    >>> analytics.webstats_js == u""
+    True
+    >>> text = manager.render()
+    >>> 'id="plone-analytics"' in text
+    False
+
+Set the analytics code through the controlpanel and verify it renders properly:
 
     >>> from plone.registry.interfaces import IRegistry
     >>> from zope.component import getUtility
@@ -21,20 +34,17 @@ Set analytics (webstats_js) code through the controlpanel
     >>> registry = getUtility(IRegistry)
     >>> site_settings = registry.forInterface(ISiteSchema, prefix="plone")
     >>> site_settings.webstats_js = u"<script>window.title='Hello'</script>"
-    >>> manager.update()
+    >>> analytics.webstats_js == site_settings.webstats_js
+    True
     >>> text = manager.render()
+    >>> 'id="plone-analytics"' in text
+    True
     >>> site_settings.webstats_js in text
     True
 
 Now enter some non-ascii text
 
     >>> site_settings.webstats_js = u"<script>window.title='C\xedsa\u0159'</script>"
-    >>> manager.update()
     >>> text = manager.render()
     >>> site_settings.webstats_js in text
-    True
-
-Check if the div sorrounding the script is present
-
-    >>> 'id="plone-analytics"' in text
     True

--- a/plone/app/layout/analytics/view.pt
+++ b/plone/app/layout/analytics/view.pt
@@ -1,8 +1,7 @@
-<div
-  id="plone-analytics"
-  tal:condition="view/webstats_js"
-  tal:content="structure view/webstats_js"
+<div id="plone-analytics"
+     tal:define="webstats_js view/webstats_js"
+     tal:condition="webstats_js"
+     tal:content="structure webstats_js"
 >
   Here goes the webstats_js
 </div>
-

--- a/plone/app/layout/analytics/view.py
+++ b/plone/app/layout/analytics/view.py
@@ -16,18 +16,20 @@ class AnalyticsViewlet(BrowserView):
     def __init__(self, context, request, view, manager):
         super(AnalyticsViewlet, self).__init__(context, request)
         self.__parent__ = view
-        self.context = context
-        self.request = request
         self.view = view
         self.manager = manager
 
-    def update(self):
-        """render the webstats snippet"""
+    @property
+    def webstats_js(self):
         registry = getUtility(IRegistry)
         site_settings = registry.forInterface(
             ISiteSchema, prefix="plone", check=False)
         try:
-            if site_settings.webstats_js:
-                self.webstats_js = site_settings.webstats_js
+            return site_settings.webstats_js or u""
         except AttributeError:
-            self.webstats_js = u""
+            return u""
+
+    def update(self):
+        """ The viewlet manager _updateViewlets requires this method
+        """
+        pass


### PR DESCRIPTION
Analytics viewlet: make webstats_js a property, so that it does not rely on an a call to the update method to be correctly evaluated

Fixes #227