### PR TITLE
Integrate Plone20200121 hotfix: prevent XSS in title.

### DIFF
--- a/news/3021.bugfix
+++ b/news/3021.bugfix
@@ -1,0 +1,3 @@
+Integrate Plone20200121 hotfix: prevent XSS in title.
+Part of https://plone.org/security/hotfix/20200121/xss-in-the-title-field-on-plone-5-0-and-higher
+[maurits]

--- a/plone/app/layout/viewlets/common.py
+++ b/plone/app/layout/viewlets/common.py
@@ -365,6 +365,10 @@ class GlobalSectionsViewlet(ViewletBase):
             item.update(
                 {"sub": sub, "opener": "", "aria_haspopup": "", "has_sub_class": "",}
             )
+        if "title" in item:
+            item["title"] = escape(item["title"])
+        if "name" in item:
+            item["name"] = escape(item["name"])
         return self._item_markup_template.format(**item)
 
     def build_tree(self, path, first_run=True):


### PR DESCRIPTION
Part of https://plone.org/security/hotfix/20200121/xss-in-the-title-field-on-plone-5-0-and-higher

Only needed on master.