### PR TITLE
Make navtree more robust against empty title

### DIFF
--- a/news/237.bugfix
+++ b/news/237.bugfix
@@ -1,0 +1,2 @@
+Make navtree more robust against empty title or name, do not fail but fall back to id.
+[jensens]

--- a/plone/app/layout/viewlets/common.py
+++ b/plone/app/layout/viewlets/common.py
@@ -365,9 +365,9 @@ class GlobalSectionsViewlet(ViewletBase):
             item.update(
                 {"sub": sub, "opener": "", "aria_haspopup": "", "has_sub_class": "",}
             )
-        if "title" in item:
+        if "title" in item and item["title"]:
             item["title"] = escape(item["title"])
-        if "name" in item:
+        if "name" in item and item["name"]:
             item["name"] = escape(item["name"])
         return self._item_markup_template.format(**item)
 

--- a/plone/app/layout/viewlets/sections.pt
+++ b/plone/app/layout/viewlets/sections.pt
@@ -19,7 +19,7 @@
 
       <div class="plone-collapse plone-navbar-collapse" id="portal-globalnav-collapse">
         <ul class="plone-nav plone-navbar-nav" id="portal-globalnav">
-          <navtree tal:replace="structure view/render_globalnav" />
+          <navtree tal:replace="structure python:view.render_globalnav()" />
         </ul>
       </div>
     </div>


### PR DESCRIPTION
If - for some odd reason - title or name is None, False or Missing.Value do not fail rendering.