### PR TITLE
Prevent breaking changes inside a minor Plone release

### DIFF
--- a/news/239.bugfix
+++ b/news/239.bugfix
@@ -1,0 +1,1 @@
+Restore selectedTabs code that was removed in 3.4.1 to prevent breaking changes inside a minor Plone release. Plone doesn't use this code anymore, but third party addons may use it.

--- a/plone/app/layout/viewlets/common.py
+++ b/plone/app/layout/viewlets/common.py
@@ -394,6 +394,54 @@ class GlobalSectionsViewlet(ViewletBase):
         )
         return portal_tabs_view.topLevelTabs()
 
+    @deprecate("This method will be removed in Plone 6")
+    def selectedTabs(self, default_tab="index_html", portal_tabs=()):
+        portal = getToolByName(self.context, "portal_url").getPortalObject()
+        plone_url = getNavigationRootObject(self.context, portal).absolute_url()
+        plone_url_len = len(plone_url)
+        request = self.request
+        valid_actions = []
+
+        url = request["URL"]
+        path = url[plone_url_len:]
+        path_list = path.split("/")
+        if len(path_list) <= 1:
+            return {"portal": default_tab}
+
+        for action in portal_tabs:
+            if not action["url"].startswith(plone_url):
+                # In this case the action url is an external link. Then, we
+                # avoid issues (bad portal_tab selection) continuing with next
+                # action.
+                continue
+            action_path = action["url"][plone_url_len:]
+            if not action_path.startswith("/"):
+                action_path = "/" + action_path
+            action_path_list = action_path.split("/")
+            if action_path_list[1] == path_list[1]:
+                # Make a list of the action ids, along with the path length
+                # for choosing the longest (most relevant) path.
+                valid_actions.append((len(action_path_list), action["id"]))
+
+        # Sort by path length, the longest matching path wins
+        valid_actions.sort()
+        if valid_actions:
+            return {"portal": valid_actions[-1][1]}
+
+        return {"portal": default_tab}
+
+    @property
+    @memoize
+    @deprecate("This method will be removed in Plone 6")
+    def selected_tabs(self):
+        return self.selectedTabs(portal_tabs=self.portal_tabs)
+
+    @property
+    @memoize
+    @deprecate("This method will be removed in Plone 6")
+    def selected_portal_tab(self):
+        return self.selected_tabs["portal"]
+
 
 class PersonalBarViewlet(ViewletBase):
 


### PR DESCRIPTION
This is a partial revert of 8253ecb which was introducing breaking changes.
It adds deprecation warnings that claim that the restored code will be removed again in Plone 6.

Fixes #239