### PR TITLE
Made the error page recognisable again in the body classes.

### DIFF
--- a/news/242.bugfix
+++ b/news/242.bugfix
@@ -1,0 +1,4 @@
+Made the error page recognisable again in the body classes.
+Instead of ``template-index-html`` you now get ``template-error_message-pt``.
+Compatibility note: in Plone 5.1 and earlier, this was ``template-default_error_message``.
+[maurits]


### PR DESCRIPTION
Instead of `template-index-html` you now get `template-error_message-pt`.
Compatibility note: in Plone 5.1 and earlier, this was `template-default_error_message`.
Fixes issue #242.

I created a new method `_template_name` for this, making this easier to override.

To get a general idea of what template names and view names can be,
here are some sample combinations from clicking around in the site with an extra print statement:

```
Template name='listing_summary.pt'. View name='summary_view'.
Template name='document.pt'. View name='document_view'.
Template name='event_listing.pt'. View name='event_listing'.
Template name='image.pt'. View name='image_view'.
Template name='error_message.pt'. View name='index.html'.
Template name='login.pt'. View name='login'.
Template name='overview.pt'. View name='overview-controlpanel'.
Template name='actions.pt'. View name='actions-controlpanel'.
Template name='form.pt'. View name='new-action'.
Template name='quickinstaller.pt'. View name='prefs_install_products_form'.
Template name='document.pt'. View name='document_view'.
Template name='layout.pt'. View name='edit'.
```

In those examples, the error message template is the only case where this PR changes anything.