### PR TITLE
Navtree adaptions (3.4.x)

### DIFF
--- a/news/273-1.feature
+++ b/news/273-1.feature
@@ -1,0 +1,4 @@
+Global section viewlet: Catalog based navigation.
+Show the global sections also if navigation contains items but tabs are empty.
+This allows for disabling portal tabs rendering and constructing the navigation only from the catalog query.
+[thet]

--- a/news/273-2.feature
+++ b/news/273-2.feature
@@ -1,0 +1,3 @@
+Global sections viewlet: Customize entries and query.
+Also allow customizing the tabs entries and the navigation query along with the other navigation entries.
+[thet]

--- a/news/273-3.feature
+++ b/news/273-3.feature
@@ -1,0 +1,3 @@
+Global sections viewlet: Factor out types_using_view.
+Factor out types_using_view so that this method can be re-used, e.g. in a subclass with a customize_entry method.
+[thet]

--- a/plone/app/layout/viewlets/common.py
+++ b/plone/app/layout/viewlets/common.py
@@ -276,7 +276,8 @@ class GlobalSectionsViewlet(ViewletBase):
     def navtree(self):
         ret = defaultdict(list)
         navtree_path = self.navtree_path
-        for tab in self.portal_tabs:
+        portal_tabs = self.portal_tabs
+        for tab in portal_tabs:
             entry = tab.copy()
             entry.update(
                 {"path": "/".join((navtree_path, tab["id"])), "uid": tab["id"],}
@@ -328,7 +329,7 @@ class GlobalSectionsViewlet(ViewletBase):
         for brain in brains:
             brain_path = brain.getPath()
             brain_parent_path = brain_path.rpartition("/")[0]
-            if brain_parent_path == navtree_path:
+            if portal_tabs and brain_parent_path == navtree_path:
                 # This should be already provided by the portal_tabs_view
                 continue
             if brain.exclude_from_nav and not context_path.startswith(brain_path):

--- a/plone/app/layout/viewlets/common.py
+++ b/plone/app/layout/viewlets/common.py
@@ -272,6 +272,13 @@ class GlobalSectionsViewlet(ViewletBase):
         )
 
     @property
+    @memoize_contextless
+    def types_using_view(self):
+        registry = getUtility(IRegistry)
+        types_using_view = registry.get("plone.types_use_view_action_in_listings", [])
+        return types_using_view
+
+    @property
     @memoize
     def navtree(self):
         ret = defaultdict(list)
@@ -325,9 +332,7 @@ class GlobalSectionsViewlet(ViewletBase):
         portal_catalog = getToolByName(self.context, "portal_catalog")
         brains = portal_catalog.searchResults(**query)
 
-        registry = getUtility(IRegistry)
-        types_using_view = registry.get("plone.types_use_view_action_in_listings", [])
-
+        types_using_view = self.types_using_view
         for brain in brains:
             brain_path = brain.getPath()
             brain_parent_path = brain_path.rpartition("/")[0]

--- a/plone/app/layout/viewlets/common.py
+++ b/plone/app/layout/viewlets/common.py
@@ -294,6 +294,7 @@ class GlobalSectionsViewlet(ViewletBase):
                 )
 
             entry["title"] = safe_unicode(entry["title"])
+            self.customize_tab(entry, tab)
             ret[navtree_path].append(entry)
 
         if not self.settings.generate_tabs:
@@ -320,6 +321,7 @@ class GlobalSectionsViewlet(ViewletBase):
             query["exclude_from_nav"] = False
 
         context_path = "/".join(self.context.getPhysicalPath())
+        self.customize_query(query)
         portal_catalog = getToolByName(self.context, "portal_catalog")
         brains = portal_catalog.searchResults(**query)
 
@@ -348,10 +350,19 @@ class GlobalSectionsViewlet(ViewletBase):
             }
             self.customize_entry(entry, brain)
             ret[brain_parent_path].append(entry)
+
         return ret
 
+    def customize_query(self, query):
+        """Helper to customize the catalog query."""
+        pass
+
+    def customize_tab(self, entry, tab):
+        """Helper to add custom entry keys/values."""
+        pass
+
     def customize_entry(self, entry, brain):
-        """a little helper to add custom entry keys/values."""
+        """Helper to add custom entry keys/values."""
         pass
 
     def render_item(self, item, path):

--- a/plone/app/layout/viewlets/sections.pt
+++ b/plone/app/layout/viewlets/sections.pt
@@ -2,8 +2,7 @@
      xmlns:tal="http://xml.zope.org/namespaces/tal"
      xmlns:metal="http://xml.zope.org/namespaces/metal"
      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-     tal:define="portal_tabs view/portal_tabs"
-     tal:condition="portal_tabs"
+     tal:condition="python:view.navtree"
      i18n:domain="plone">
 
   <nav class="plone-navbar pat-navigationmarker" id="portal-globalnav-wrapper">

--- a/plone/app/layout/viewlets/tests/test_common.py
+++ b/plone/app/layout/viewlets/tests/test_common.py
@@ -510,6 +510,21 @@ class TestGlobalSectionsViewlet(ViewletsTestCase):
             ["/plone/excluded-folder/sub-folder"],
         )
 
+    def test_generate_tabs__no_portal_tabs(self):
+        """Test for constructing the navigation purely out of a catalog query
+        and not using portal tabs at all."""
+
+        class CustomGlobalSectionsViewlet(GlobalSectionsViewlet):
+            portal_tabs = []
+
+        self.portal.invokeFactory("Folder", id="folder1", title="Folder 1")
+
+        nav = CustomGlobalSectionsViewlet(self.portal, self.request.clone(), None)
+        navtree = nav.navtree
+
+        self.assertEqual(navtree["/plone"][0]["id"], "Members")
+        self.assertEqual(navtree["/plone"][1]["id"], "folder1")
+
 
 class TestTitleEscape(ViewletsFunctionalTestCase):
     """Test that the title in the global sections viewlet is escaped.

--- a/plone/app/layout/viewlets/tests/test_common.py
+++ b/plone/app/layout/viewlets/tests/test_common.py
@@ -581,6 +581,27 @@ class TestGlobalSectionsViewlet(ViewletsTestCase):
         self.assertEqual(len(navtree["/plone"]), 1)
         self.assertEqual(navtree["/plone"][0]["title"], "Folder 1")
 
+    def test_types_using_view(self):
+        """Test for constructing the navigation purely out of a catalog query
+        and not using portal tabs at all."""
+
+        class CustomGlobalSectionsViewlet(GlobalSectionsViewlet):
+            portal_tabs = []
+            types_using_view = ["Folder"]
+
+        self.portal.invokeFactory("Folder", id="folder1", title="Folder 1")
+
+        nav = CustomGlobalSectionsViewlet(self.portal, self.request.clone(), None)
+        navtree = nav.navtree
+
+        self.assertListEqual(nav.types_using_view, ["Folder"])
+        self.assertEqual(
+            navtree["/plone"][0]["url"], "http://nohost/plone/Members/view"
+        )
+        self.assertEqual(
+            navtree["/plone"][1]["url"], "http://nohost/plone/folder1/view"
+        )
+
 
 class TestTitleEscape(ViewletsFunctionalTestCase):
     """Test that the title in the global sections viewlet is escaped.

--- a/plone/app/layout/viewlets/tests/test_common.py
+++ b/plone/app/layout/viewlets/tests/test_common.py
@@ -525,6 +525,62 @@ class TestGlobalSectionsViewlet(ViewletsTestCase):
         self.assertEqual(navtree["/plone"][0]["id"], "Members")
         self.assertEqual(navtree["/plone"][1]["id"], "folder1")
 
+    def test_customize_tabs(self):
+        """Test for constructing the navigation purely out of a catalog query
+        and not using portal tabs at all."""
+        self.registry["plone.generate_tabs"] = False
+
+        class CustomGlobalSectionsViewlet(GlobalSectionsViewlet):
+            def customize_tab(self, entry, tab):
+                entry["title"] = "Homepage"
+                return entry
+
+        nav = CustomGlobalSectionsViewlet(self.portal, self.request.clone(), None)
+        navtree = nav.navtree
+
+        self.assertEqual(navtree["/plone"][0]["title"], "Homepage")
+
+    def test_customize_entry(self):
+        """Test for constructing the navigation purely out of a catalog query
+        and not using portal tabs at all."""
+
+        class CustomGlobalSectionsViewlet(GlobalSectionsViewlet):
+            portal_tabs = []
+
+            def customize_entry(self, entry, brain):
+                entry["title"] = "OKAY"
+                return entry
+
+        self.portal.invokeFactory("Folder", id="folder1", title="Folder 1")
+
+        nav = CustomGlobalSectionsViewlet(self.portal, self.request.clone(), None)
+        navtree = nav.navtree
+
+        self.assertEqual(navtree["/plone"][0]["title"], "OKAY")
+        self.assertEqual(navtree["/plone"][1]["title"], "OKAY")
+
+    def test_customize_query(self):
+        """Test for constructing the navigation purely out of a catalog query
+        and not using portal tabs at all."""
+
+        class CustomGlobalSectionsViewlet(GlobalSectionsViewlet):
+            portal_tabs = []
+
+            def customize_query(self, query):
+                query["id"] = "folder1"
+                return query
+
+        self.portal.invokeFactory(
+            "Folder", id="folder1", title="Folder 1", language="sl"
+        )
+        self.portal.invokeFactory("Folder", id="folder2", title="Folder 2")
+
+        nav = CustomGlobalSectionsViewlet(self.portal, self.request.clone(), None)
+        navtree = nav.navtree
+
+        self.assertEqual(len(navtree["/plone"]), 1)
+        self.assertEqual(navtree["/plone"][0]["title"], "Folder 1")
+
 
 class TestTitleEscape(ViewletsFunctionalTestCase):
     """Test that the title in the global sections viewlet is escaped.


### PR DESCRIPTION
Targets Plone 5.2 / plone.app.layout 3.4.x
PR for Plone 6 is here: https://github.com/plone/plone.app.layout/pull/274

## Changes

1) Global section viewlet: Catalog based navigation.
Show the global sections also if navigation contains items but tabs are empty.
This allows for disabling portal tabs rendering and constructing the navigation only from the catalog query.

2) Global sections viewlet: Customize entries and query.
Also allow customizing the tabs entries and the navigation query along with the other navigation entries.

3) Global sections viewlet: Factor out types_using_view.
Factor out types_using_view so that this method can be re-used, e.g. in a subclass with a customize_entry method.

## Motivation

I need to customize the navigation for a project where I want to display the original language navigation entry plus a translated navigation entry at the same time. For that I need to customize the catalog navigation entry. I can't do that with the tabs based entries because the tabs contain too little context information resp. I need the brain to customize the entry. Along the way I added methods to customize the query and tabs too. ....