### PR TITLE
Global sections viewlet performance optimizations

### DIFF
--- a/news/275.feature
+++ b/news/275.feature
@@ -1,0 +1,7 @@
+Global sections viewlet performance optimizations:
+
+- Remove pointless caching on types_using_view,
+- Store settings in variable for multiple access, bypassing cache checks,
+- Remove now pointless caching on settings property,
+- Deprecate now unused navtree_depth property.
+[thet]


### PR DESCRIPTION
For 3.4.x / Plone 5.2
Branch for Plone 6: https://github.com/plone/plone.app.layout/pull/276

- Remove pointless caching on types_using_view,
- Store settings in variable for multiple access, bypassing cache checks,
- Remove now pointless caching on settings property,
- Deprecate now unused navtree_depth property.