### PR TITLE
Global sections viewlet performance optimizations

### DIFF
--- a/news/275.feature
+++ b/news/275.feature
@@ -1,0 +1,7 @@
+Global sections viewlet performance optimizations:
+
+- Remove pointless caching on types_using_view,
+- Store settings in variable for multiple access, bypassing cache checks,
+- Remove now pointless caching on settings property,
+- Deprecate now unused navtree_depth property.
+[thet]


### PR DESCRIPTION
For master / Plone 6
PR for Plone 5.2: https://github.com/plone/plone.app.layout/pull/275

- Remove pointless caching on types_using_view,
- Store settings in variable for multiple access, bypassing cache checks,
- Remove now pointless caching on settings property,
- Deprecate now unused navtree_depth property.