### PR TITLE
Escape navigation titles only once (3.x)

### DIFF
--- a/news/280.fix
+++ b/news/280.fix
@@ -1,0 +1,2 @@
+Escape navigation titles only once.
+[thomasmassmann]

--- a/plone/app/layout/viewlets/common.py
+++ b/plone/app/layout/viewlets/common.py
@@ -302,7 +302,9 @@ class GlobalSectionsViewlet(ViewletBase):
                     entry["title"], domain="plone", context=self.request
                 )
 
-            entry["title"] = safe_unicode(entry["title"])
+            entry["title"] = escape(safe_unicode(entry["title"]))
+            if "name" in entry and entry["name"]:
+                entry["name"] = escape(safe_unicode(entry["name"]))
             self.customize_tab(entry, tab)
             ret[navtree_path].append(entry)
 
@@ -355,7 +357,7 @@ class GlobalSectionsViewlet(ViewletBase):
                 "path": brain_path,
                 "uid": brain.UID,
                 "url": url,
-                "title": safe_unicode(brain.Title),
+                "title": escape(safe_unicode(brain.Title)),
                 "review_state": brain.review_state,
             }
             self.customize_entry(entry, brain)
@@ -390,10 +392,6 @@ class GlobalSectionsViewlet(ViewletBase):
             item.update(
                 {"sub": sub, "opener": "", "aria_haspopup": "", "has_sub_class": "",}
             )
-        if "title" in item and item["title"]:
-            item["title"] = escape(item["title"])
-        if "name" in item and item["name"]:
-            item["name"] = escape(item["name"])
         return self._item_markup_template.format(**item)
 
     def build_tree(self, path, first_run=True):

--- a/plone/app/layout/viewlets/tests/test_common.py
+++ b/plone/app/layout/viewlets/tests/test_common.py
@@ -602,6 +602,26 @@ class TestGlobalSectionsViewlet(ViewletsTestCase):
             navtree["/plone"][1]["url"], "http://nohost/plone/folder1/view"
         )
 
+    def test_escaping_twice_does_not_double_escape_items(self):
+        """Test for https://github.com/plone/plone.app.layout/issues/280."""
+
+        self.portal.invokeFactory(
+            "Document", "test-doc-1", title=u"Document 1 & 2",
+        )
+
+        request = self.layer["request"]
+        gsv = GlobalSectionsViewlet(self.portal, request, None)
+        gsv.update()
+        html = gsv.render()
+        self.assertIn("Document 1 &amp; 2", html)
+
+        # Render again, as this is what happens when an error view is rendered
+        # Before the fix this test will fail, as it produces a title with
+        # 'Document 1 &amp;amp; 2'.
+        html = gsv.render()
+        self.assertNotIn("Document 1 &amp;amp; 2", html)
+        self.assertIn("Document 1 &amp; 2", html)
+
 
 class TestTitleEscape(ViewletsFunctionalTestCase):
     """Test that the title in the global sections viewlet is escaped.


### PR DESCRIPTION
Fix for #280 