### PR TITLE
Correct favicon handling.

### DIFF
--- a/news/290.bugfix
+++ b/news/290.bugfix
@@ -1,1 +1,1 @@
-Correct favicon handling -- fix URL to navroot/favicon.ico and use customized icon file name as part of the proxy cache key.
+Correct favicon handling: fix URL to navroot/favicon.ico and use customized icon file name as part of the proxy cache key.

--- a/news/290.bugfix
+++ b/news/290.bugfix
@@ -1,1 +1,1 @@
-Correct favicon handling -- fix URL to navroot/favicon.ico and ignore uploader file name.
+Correct favicon handling -- fix URL to navroot/favicon.ico and use customized icon file name as part of the proxy cache key.

--- a/news/290.bugfix
+++ b/news/290.bugfix
@@ -1,0 +1,1 @@
+Correct favicon handling -- fix URL to navroot/favicon.ico and ignore uploader file name.

--- a/plone/app/layout/favicon_handler.py
+++ b/plone/app/layout/favicon_handler.py
@@ -15,5 +15,5 @@ def updateMimetype(settings: RecordsProxy, event: IRecordModifiedEvent=None):
         return
 
     filename, data = b64decode_file(event.newValue)
-    mimetype = mimetypes.guess_type(filename)[0] if filename else 'image/x-icon'
+    mimetype = mimetypes.guess_type(filename)[0] if filename else 'image/vnd.microsoft.icon'
     settings.__registry__['plone.site_favicon_mimetype'] = mimetype

--- a/plone/app/layout/favicon_handler.py
+++ b/plone/app/layout/favicon_handler.py
@@ -14,6 +14,10 @@ def updateMimetype(settings: RecordsProxy, event: IRecordModifiedEvent=None):
     if event.record.fieldName != 'site_favicon' or not event.record.value:
         return
 
-    filename, data = b64decode_file(event.newValue)
-    mimetype = mimetypes.guess_type(filename)[0] if filename else 'image/vnd.microsoft.icon'
+    filename = b64decode_file(event.newValue)[0]
+    mimetype = mimetypes.guess_type(filename)[0] if filename else None
+    if mimetype in ('image/x-icon', None):
+        # Override incorrect MIME type registered in both PIL and the
+        # Products.MimetypesRegistry product.
+        mimetype = 'image/vnd.microsoft.icon'
     settings.__registry__['plone.site_favicon_mimetype'] = mimetype

--- a/plone/app/layout/links/favicon.pt
+++ b/plone/app/layout/links/favicon.pt
@@ -1,6 +1,5 @@
-<tal:favicon define="portal_url view/site_url">
+<tal:favicon>
     <link rel="preload icon" type="${python: view.mimetype}"
           tal:attributes="href python: view.favicon_path" />
-    <link rel="alternate icon" type="image/x-icon">
     <link rel="mask-icon" tal:attributes="href python: view.favicon_path" />
 </tal:favicon>

--- a/plone/app/layout/links/tests/test_favicon_viewlet.py
+++ b/plone/app/layout/links/tests/test_favicon_viewlet.py
@@ -60,11 +60,11 @@ class TestFaviconViewletView(ViewletsTestCase, FaviconViewlet):
         encoded_data = b64encode_file(filename=filename, data=file_data)
         settings.site_favicon = encoded_data
         mimetype = settings.site_favicon_mimetype
-        self.assertEqual(mimetype, 'image/x-icon')
+        self.assertEqual(mimetype, 'image/vnd.microsoft.icon')
 
     def test_FaviconViewlet_get_mimetype_none(self):
         registry = getUtility(IRegistry)
         settings = registry.forInterface(ISiteSchema, prefix="plone")
         settings.site_favicon = None
         mimetype = settings.site_favicon_mimetype
-        self.assertEqual(mimetype, 'image/x-icon')
+        self.assertEqual(mimetype, 'image/vnd.microsoft.icon')

--- a/plone/app/layout/links/viewlets.py
+++ b/plone/app/layout/links/viewlets.py
@@ -74,11 +74,7 @@ class FaviconViewlet(ViewletBase):
         # URL.  This does not cover the case of RSS and podcast apps that access
         # /favicon.ico by custom instead of consulting the HTML, but at least
         # it covers pretty much every browser out there.
-        self.favicon_path: str = "".join([
-            str(self.navigation_root_url),
-            "/favicon.ico",
-            cachebust,
-        ])
+        self.favicon_path: str = f"{self.navigation_root_url}/favicon.ico{cachebust}"
 
     def render(self) -> ViewPageTemplateFile:
         self.init_favicon()

--- a/plone/app/layout/links/viewlets.py
+++ b/plone/app/layout/links/viewlets.py
@@ -51,7 +51,8 @@ class FaviconViewlet(ViewletBase):
         cachebust = ""
         if getattr(settings, "site_favicon", False):
             # The user has customized the favicon via the Site configlet.
-            filename, unused_data = b64decode_file(settings.site_favicon)
+            filename = b64decode_file(settings.site_favicon)[0]
+            
             cachebust = "?name=" + filename
         # The filename is *always* /favicon.ico, irrespective of the content type,
         # because:


### PR DESCRIPTION
As per https://github.com/plone/Products.CMFPlone/pull/3418#issuecomment-1027118882

1. Remove alternate icon HTML, since we do not serve alternate icons, since we do not actually provide the user with a mechanism to upload alternate icons, and serving the default Plone icon as an alternate would cause branding problems for site operators.
2. Hardcode icon URL to /favicon.ico, rooted in the site navigation root, rather than the overall site root, as the icon serving is done per site navigation root, not per site root.
3. Ignore file name uploaded by the uploader.  Unlike the site logo, which could and should vary in file name, there was no point in serving the file name, since the view that actually serves the data (in CMFPlone) cannot "rename itself" according to the file name of the icon that the user uploaded when he uploaded the custom icon.
4. Instead of informing the browser that the favicon is at /favicon or /favicon.ico depending on whether the user has customized the favicon, simply inform the browser that the favicon is always at navroot/favicon.ico, and then the CMFPlone view is in charge of serving the correct data to the user.

We preserve the cache-busting properties of uploadable base64-encoded files with filenames, by reusing the filenames as part of the URL we suggest to the browser is the favicon.  Of course `/favicon.ico` without any file name works fine.