### PR TITLE
Remove href from toolbar header link

### DIFF
--- a/news/313.bugfix
+++ b/news/313.bugfix
@@ -1,0 +1,2 @@
+Fix toolbar header toggle (do not change url when clicking).
+[petschki]

--- a/plone/app/layout/viewlets/toolbar.pt
+++ b/plone/app/layout/viewlets/toolbar.pt
@@ -11,10 +11,10 @@
        class="pat-toolbar" data-bs-scroll="true">
 
     <div class="toolbar-header nav">
-      <a class="toolbar-collapse" aria-label="Unpin" href="#edit-zone">
+      <a class="toolbar-collapse" aria-label="Unpin">
         <tal:icon tal:replace="structure python:icons.tag('arrow-bar-left')" />
       </a>
-      <a class="toolbar-expand" aria-label="Pin" href="#edit-zone">
+      <a class="toolbar-expand" aria-label="Pin">
         <tal:icon tal:replace="structure python:icons.tag('arrow-bar-right')" />
       </a>
     </div>


### PR DESCRIPTION
this changes window.location and triggers some ajax calls, for example in `pat-manage-portlets`