### PR TITLE
get the title from the registry in case the navigation root is the portal object

### DIFF
--- a/news/317.bugfix
+++ b/news/317.bugfix
@@ -1,0 +1,2 @@
+get the title of the navigation root from the registry when the navigation root object is the portal object
+[erral]

--- a/plone/app/layout/globals/portal.py
+++ b/plone/app/layout/globals/portal.py
@@ -8,6 +8,7 @@ from plone.memoize.view import memoize_contextless
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces import IPloneSiteRoot
 from plone.base.interfaces import ISearchSchema
 from plone.base.interfaces import ISiteSchema
 from Products.Five.browser import BrowserView
@@ -51,6 +52,10 @@ class PortalState(BrowserView):
 
     @memoize
     def navigation_root_title(self):
+        navigation_root = self.navigation_root()
+        if IPloneSiteRoot.providedBy(navigation_root):
+            return self.portal_title()
+
         title = self.navigation_root().Title
         if callable(title):
             return title()

--- a/plone/app/layout/globals/tests/test_portal.py
+++ b/plone/app/layout/globals/tests/test_portal.py
@@ -65,7 +65,9 @@ class TestPortalStateView(unittest.TestCase):
         self.assertEqual(view.navigation_root_path(), getNavigationRoot(self.folder))
 
     def test_navigation_root_title(self):
-        self.portal.Title = "Portal title"
+        registry = getUtility(IRegistry)
+        self.site_settings = registry.forInterface(ISiteSchema, prefix="plone")
+        self.site_settings.site_title = "Portal title"
         self.assertEqual(self.view.navigation_root_title(), "Portal title")
         members = self.portal["Members"]
         # mark a folder "between" self.folder and self.portal with


### PR DESCRIPTION
Fixes #317 for master

To be tested  and merged with https://github.com/plone/Products.CMFPlone/pull/3587