### PR TITLE
show full datetime in toolbar modification time

### DIFF
--- a/news/325.bugfix
+++ b/news/325.bugfix
@@ -1,0 +1,2 @@
+Show modification datetime in toolbar with full datetime according to locale format
+[erral]

--- a/plone/app/layout/viewlets/menu.pt
+++ b/plone/app/layout/viewlets/menu.pt
@@ -23,7 +23,7 @@
             <span class="toolbar-label">
               <time
                 class="pat-display-time"
-                data-pat-display-time="from-now: true"
+                data-pat-display-time="output-format: L LTS"
                 datetime="${context/ModificationDate}"
                 tal:content="">${context/ModificationDate}</time>
             </span>


### PR DESCRIPTION
Fixes #325 
Fixes https://github.com/plone/mockup/issues/1219

This PR is to keep consistency between Volto and Classic-UI. See Volto issues:
https://github.com/plone/volto/issues/3620
https://github.com/plone/volto/pull/3625