### PR TITLE
fix circular depedendcy, also rm AT deps

### DIFF
--- a/news/rm-archetypes-code.bugfix
+++ b/news/rm-archetypes-code.bugfix
@@ -1,0 +1,2 @@
+Remove dead code for Archetypes relations lookup.
+[@jensens]

--- a/news/rm-dep-pamultilingual.bugfix
+++ b/news/rm-dep-pamultilingual.bugfix
@@ -1,0 +1,5 @@
+Add another unused `get_translations` method to deprecated ones.
+Circula dependency on plone.app.multilingual is only for unused deprecated methods.
+Move it's imports into methods-body and remove dependency from setup.py.
+[@jensens]
+

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     install_requires=[
         "BTrees",
         "plone.app.content",
-        "plone.app.multilingual",
         "plone.app.relationfield",
         "plone.app.uuid",
         "plone.app.viewletmanager >=1.2",


### PR DESCRIPTION
- Remove dead code for Archetypes relations lookup.
- Add another unused `get_translations` method to deprecated ones.
  Circular dependency on plone.app.multilingual is only for unused deprecated methods.
  Move it's imports into methods-body and remove dependency from setup.py.