### PR TITLE
Add back all action properties

### DIFF
--- a/plone/app/layout/viewlets/toolbar.pt
+++ b/plone/app/layout/viewlets/toolbar.pt
@@ -70,7 +70,7 @@
         </li>
         <li tal:repeat="action personal_bar/user_actions">
           <a class="nav-link dropdown-item"
-             href="${action/href}"
+             tal:attributes="action"
           >
             <tal:icon replace="structure python:icons.tag(action.get('icon', 'dot'), tag_class='')" />
             <tal:actionname tal:content="action/title">


### PR DESCRIPTION
@petschki on commit https://github.com/plone/plone.app.layout/commit/aca4c803c874cc295e88959eb918eeea04133024#diff-19d7b7f9374b13d31acb35303c06d78a0c95494f99949c1897e1aae3f0e07b1a `tal:attributes="action"` was removed from the personal tools menu.

I noticed that now, because I have a local tests that checks which links are shown on that menu, and since that change of yours the `id` attribute is gone 😱

Was that on purpose (sorry to ask more than a year later 😆 😅 ) or by mistake?