### PR TITLE
Fix adapter registration

### DIFF
--- a/news/+fix-adapter.bugfix
+++ b/news/+fix-adapter.bugfix
@@ -1,0 +1,2 @@
+Fix `DefaultBodyClasses` adapter registration.
+[gforcada]

--- a/plone/app/layout/globals/configure.zcml
+++ b/plone/app/layout/globals/configure.zcml
@@ -51,4 +51,9 @@
     <implements interface="zope.annotation.interfaces.IAttributeAnnotatable" />
   </class>
 
+  <adapter
+      factory=".layout.DefaultBodyClasses"
+      name="default-classes"
+      />
+
 </configure>

--- a/plone/app/layout/globals/layout.py
+++ b/plone/app/layout/globals/layout.py
@@ -296,7 +296,7 @@ class LayoutPolicy(BrowserView):
         return " ".join(sorted(body_classes))
 
 
-@adapter(Interface)
+@adapter(Interface, Interface)
 @implementer(IBodyClassAdapter)
 class DefaultBodyClasses:
     def __init__(self, context, request):


### PR DESCRIPTION
I was trying to add some extra classes on the `<body>` and I expected to be an adapter to extend the functionality, and indeed, there it was: `plone.app.layout.globals.interfaces.IBodyClassAdapter` ✨ 

Even better, there is already an example adapter on `plone.app.layout.globals.layout.DefaultBodyClasses` 🤩 

There is one catch though, the adapter is not registered in ZCML (so that it gets a name) and is actually a multi adapter (context, request), but it was only registered as a single adapter.

Anyway, long story short: here is a fix for it 🎉 

I'm wondering if it would make sense to already split the `LayoutPolicy` (also in `p.a.l.g.layout`) and create smaller adapters? 🤔 

Anyway, meanwhile we can fix the actual code, so anyone else wanting to add some extra classes on the `<body>` class does not have to try to figure out how that works 😄 