### PR TITLE
Fixes "by" translation and fuzzy dates for `document_byline.pt`

### DIFF
--- a/plone/app/layout/viewlets/document_byline.pt
+++ b/plone/app/layout/viewlets/document_byline.pt
@@ -10,8 +10,8 @@
   >
     <span class="label-by-author">
       <tal:i18n i18n:translate="label_by_author">
-      by
-      <tal:for repeat="user_id creator_ids" i18n:name="author">
+        by
+        <tal:for repeat="user_id creator_ids" i18n:name="author">
           <tal:user define="
                       url_path python: view.get_url_path(user_id);
                       fullname python:view.get_fullname(user_id);
@@ -39,7 +39,12 @@
           tal:condition="published"
     >
       <span i18n:translate="box_published">published</span>
-      <span tal:content="python:context.toLocalizedTime(published)">Published</span>
+      <span tal:content="published"
+            class="pat-display-time"
+            data-pat-display-time="from-now: true"
+            datetime="${published}"
+            title="${python: context.toLocalizedTime(published, long_format=True)}"
+      >Published</span>
       <tal:sep condition="show_modification_date">,</tal:sep>
     </span>
 
@@ -49,9 +54,12 @@
       <span i18n:translate="box_last_modified">
       last modified
       </span>
-      <span tal:content="python:context.toLocalizedTime(modified)">
-      Modified
-      </span>
+      <span tal:content="modified"
+            class="pat-display-time"
+            data-pat-display-time="from-now: true"
+            datetime="${modified}"
+            title="${python: context.toLocalizedTime(modified, long_format=True)}"
+      >Modified</span>
     </span>
   </tal:dates>
 

--- a/plone/app/layout/viewlets/document_byline.pt
+++ b/plone/app/layout/viewlets/document_byline.pt
@@ -9,21 +9,23 @@
                 tal:condition="python:creator_ids and view.show_about()"
   >
     <span class="label-by-author">
-      <tal:i18n i18n:translate="">by</tal:i18n>
-      <tal:for repeat="user_id creator_ids">
-        <tal:user define="
-                    url_path python: view.get_url_path(user_id);
-                    fullname python:view.get_fullname(user_id);
-                  ">
-          <a class="badge rounded-pill bg-light text-dark fw-normal fs-6"
-             href="${navigation_root_url}/${url_path}"
-             tal:condition="url_path"
-          >${fullname}</a>
-          <span class="badge rounded-pill bg-light text-dark fw-normal fs-6"
-                tal:condition="not:url_path"
-          >${fullname}</span>
-        </tal:user>
-      </tal:for>
+      <tal:i18n i18n:translate="label_by_author">
+      by
+      <tal:for repeat="user_id creator_ids" i18n:name="author">
+          <tal:user define="
+                      url_path python: view.get_url_path(user_id);
+                      fullname python:view.get_fullname(user_id);
+                    ">
+            <a class="badge rounded-pill bg-light text-dark fw-normal fs-6"
+               href="${navigation_root_url}/${url_path}"
+               tal:condition="url_path"
+            >${fullname}</a>
+            <span class="badge rounded-pill bg-light text-dark fw-normal fs-6"
+                  tal:condition="not:url_path"
+            >${fullname}</span>
+          </tal:user>
+        </tal:for>
+      </tal:i18n>
     &mdash;
     </span>
   </tal:creators>


### PR DESCRIPTION
![image](https://github.com/plone/plone.app.layout/assets/13345340/68f99cfc-0472-4fe3-9aae-8a163c630a00)
![image](https://github.com/plone/plone.app.layout/assets/13345340/1ca20fc8-d337-49d0-8254-7b995771b6a1)


**published/modified dates**

The document byline viewlet used to have fuzzy dates in Plone 5 - see https://github.com/plone/plone.app.layout/pull/61 and https://github.com/plone/Products.CMFPlone/issues/1000, which has been replaced in Plone 6 with simpl  localized date.

It lacks the information of when exactly the document has been modified, e.g. after editing a document I prefer seeing "last modified a few seconds ago" instead of the current date.

**"by" translation**

The `label_by_author` translation worked for most of the languages in Plone 5. It has been changed with [commit 2d6f75](https://github.com/plone/plone.app.layout/commit/2d6f7529a146437de614e86fc980ddc664905a7d#diff-cfd1c89c2a8a196360dbb198d3e2638d5716cf6fc07874626333655035bf6ce8) to `label_by`. Based on a quick search in `plone.app.locales` the new translation has only 7 translations out of 
 65 languages. The original `label_by_author` is much more supported with 46 translations out of the 65 languages.