### PR TITLE
[4.x/Plone6.0] The templates do not rely anymore on the toLocalizedTime skin script

### DIFF
--- a/news/396.bugfix.rst
+++ b/news/396.bugfix.rst
@@ -1,0 +1,2 @@
+The templates do not rely anymore on the toLocalizedTime skin script.
+[ale-rt]

--- a/plone/app/layout/viewlets/content.py
+++ b/plone/app/layout/viewlets/content.py
@@ -129,7 +129,8 @@ class DocumentBylineViewlet(ViewletBase):
         return False
 
     @deprecation.deprecate(
-        "The toLocalizedTime method is unused and will be removed in Plone 7"
+        "The toLocalizedTime method is unused and will be removed in Plone 7. "
+        "Use the @@plone.toLocalizedTime helper instead."
     )
     def toLocalizedTime(self, time, long_format=None, time_only=None):
         """Convert time to localized time"""
@@ -267,6 +268,10 @@ class HistoryByLineView(BrowserView):
             return self.context.expires().isPast()
         return False
 
+    @deprecation.deprecate(
+        "The toLocalizedTime method is unused and will be removed in Plone 7. "
+        "Use the @@plone.toLocalizedTime helper instead."
+    )
     def toLocalizedTime(self, time, long_format=None, time_only=None):
         """Convert time to localized time"""
         util = getToolByName(self.context, "translation_service")
@@ -526,6 +531,10 @@ class ContentHistoryViewlet(WorkflowHistoryViewlet):
         history.sort(key=lambda x: x.get("time", 0.0), reverse=True)
         return history
 
+    @deprecation.deprecate(
+        "The toLocalizedTime method is unused and will be removed in Plone 7. "
+        "Use the @@plone.toLocalizedTime helper instead."
+    )
     def toLocalizedTime(self, time, long_format=None, time_only=None):
         """Convert time to localized time"""
         util = getToolByName(self.context, "translation_service")

--- a/plone/app/layout/viewlets/content_history.pt
+++ b/plone/app/layout/viewlets/content_history.pt
@@ -30,7 +30,8 @@
                            action item/transition_title;
                            action_id python:item.get('action') or item.get('review_state', '');
                            effective item/effective_date|nothing;
-                           effectiveDate python:effective and view.toLocalizedTime(item['effective_date'],long_format=True);
+                           toLocalizedTime nocall:context/@@plone/toLocalizedTime;
+                           effectiveDate python:effective and toLocalizedTime(item['effective_date'],long_format=True);
                            isVersion python:item.get('type', '')=='versioning';
                            icons python:context.restrictedTraverse('@@iconresolver');
                          ">
@@ -62,7 +63,7 @@
                     ></span>
                   </tal:actor>
                             on
-                  <span tal:content="python:view.toLocalizedTime(item.get('time', 0.0),long_format=True)"
+                  <span tal:content="python:toLocalizedTime(item.get('time', 0.0),long_format=True)"
                         i18n:name="time"
                         i18n:translate=""
                   ></span>

--- a/plone/app/layout/viewlets/document_byline.pt
+++ b/plone/app/layout/viewlets/document_byline.pt
@@ -32,12 +32,13 @@
                published view/pub_date;
                modified context/ModificationDate;
                show_modification_date python:view.show_modification_date();
+               toLocalizedTime nocall:here/@@plone/toLocalizedTime;
              ">
     <span class="documentPublished"
           tal:condition="published"
     >
       <span i18n:translate="box_published">published</span>
-      <span tal:content="python:context.toLocalizedTime(published)">Published</span>
+      <span tal:content="python:toLocalizedTime(published)">Published</span>
       <tal:sep condition="show_modification_date">,</tal:sep>
     </span>
 
@@ -47,7 +48,7 @@
       <span i18n:translate="box_last_modified">
       last modified
       </span>
-      <span tal:content="python:context.toLocalizedTime(modified)">
+      <span tal:content="python:toLocalizedTime(modified)">
       Modified
       </span>
     </span>

--- a/plone/app/layout/viewlets/review_history.pt
+++ b/plone/app/layout/viewlets/review_history.pt
@@ -2,6 +2,7 @@
      id="review-history"
      tal:define="
        history view/workflowHistory;
+       toLocalizedTime nocall:here/@@plone/toLocalizedTime;
      "
      i18n:domain="plone"
 >
@@ -67,12 +68,12 @@
               </td>
 
               <td>
-                <span tal:replace="python:context.toLocalizedTime(item['time'],long_format=True)"></span>
+                <span tal:replace="python:toLocalizedTime(item['time'],long_format=True)"></span>
                 <span tal:condition="item/effective_date|nothing">
                   (<span tal:omit-tag=""
                         i18n:translate="label_publishing_effective"
                   >effective</span>:
-                  <span tal:replace="python: context.toLocalizedTime(item['effective_date'],long_format=True)"></span>)
+                  <span tal:replace="python: toLocalizedTime(item['effective_date'],long_format=True)"></span>)
                 </span>
               </td>
 


### PR DESCRIPTION
They use the @@plone.toLocalizedTime helper instead.

Refs. #396